### PR TITLE
Minor renaming

### DIFF
--- a/src/JsonWebToken/Cryptography/Aes128Keys.cs
+++ b/src/JsonWebToken/Cryptography/Aes128Keys.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for more information.
+
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace JsonWebToken.Internal
+{
+    internal struct Aes128Keys
+    {
+        private const int Count = 11;
+     
+        public Vector128<byte> Key0;
+        public Vector128<byte> Key1;
+        public Vector128<byte> Key2;
+        public Vector128<byte> Key3;
+        public Vector128<byte> Key4;
+        public Vector128<byte> Key5;
+        public Vector128<byte> Key6;
+        public Vector128<byte> Key7;
+        public Vector128<byte> Key8;
+        public Vector128<byte> Key9;
+        public Vector128<byte> Key10;
+
+        public void Clear()
+        {
+            ref byte that = ref Unsafe.As<Aes128Keys, byte>(ref Unsafe.AsRef(this));
+            Unsafe.InitBlock(ref that, 0, Count * 16);
+        }
+    }
+}
+#endif

--- a/src/JsonWebToken/Cryptography/Aes192Keys.cs
+++ b/src/JsonWebToken/Cryptography/Aes192Keys.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for more information.
+
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace JsonWebToken.Internal
+{
+    internal struct Aes192Keys
+    {
+        private const int Count = 13;
+
+        public Vector128<byte> Key0;
+        public Vector128<byte> Key1;
+        public Vector128<byte> Key2;
+        public Vector128<byte> Key3;
+        public Vector128<byte> Key4;
+        public Vector128<byte> Key5;
+        public Vector128<byte> Key6;
+        public Vector128<byte> Key7;
+        public Vector128<byte> Key8;
+        public Vector128<byte> Key9;
+        public Vector128<byte> Key10;
+        public Vector128<byte> Key11;
+        public Vector128<byte> Key12;
+
+        public void Clear()
+        {
+            ref byte that = ref Unsafe.As<Aes192Keys, byte>(ref Unsafe.AsRef(this));
+            Unsafe.InitBlock(ref that, 0, Count * 16);
+        }
+    }
+}
+#endif

--- a/src/JsonWebToken/Cryptography/Aes256Keys.cs
+++ b/src/JsonWebToken/Cryptography/Aes256Keys.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
+// Licensed under the MIT license. See the LICENSE file in the project root for more information.
+
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace JsonWebToken.Internal
+{
+    internal struct Aes256Keys
+    {
+        private const int Count = 15;
+
+        public Vector128<byte> Key0;
+        public Vector128<byte> Key1;
+        public Vector128<byte> Key2;
+        public Vector128<byte> Key3;
+        public Vector128<byte> Key4;
+        public Vector128<byte> Key5;
+        public Vector128<byte> Key6;
+        public Vector128<byte> Key7;
+        public Vector128<byte> Key8;
+        public Vector128<byte> Key9;
+        public Vector128<byte> Key10;
+        public Vector128<byte> Key11;
+        public Vector128<byte> Key12;
+        public Vector128<byte> Key13;
+        public Vector128<byte> Key14;
+
+        public void Clear()
+        {
+            ref byte that = ref Unsafe.As<Aes256Keys, byte>(ref Unsafe.AsRef(this));
+            Unsafe.InitBlock(ref that, 0, Count * 16);
+        }
+    }
+}
+#endif

--- a/src/JsonWebToken/Cryptography/AesGcmDecryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmDecryptor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Security.Cryptography;
 

--- a/src/JsonWebToken/Cryptography/AesGcmDecryptor.netstandard20.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmDecryptor.netstandard20.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 using System;
 
 namespace JsonWebToken.Internal

--- a/src/JsonWebToken/Cryptography/AesGcmEncryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmEncryptor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Security.Cryptography;
 

--- a/src/JsonWebToken/Cryptography/AesGcmEncryptor.netstandard20.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmEncryptor.netstandard20.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 using System;
 
 namespace JsonWebToken.Internal

--- a/src/JsonWebToken/Cryptography/AesGcmKeyUnwrapper.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmKeyUnwrapper.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Security.Cryptography;
 

--- a/src/JsonWebToken/Cryptography/AesGcmKeyUnwrapper.netstandard20.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmKeyUnwrapper.netstandard20.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 using System;
 
 namespace JsonWebToken.Internal

--- a/src/JsonWebToken/Cryptography/AesGcmKeyWrapper.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmKeyWrapper.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Security.Cryptography;
 

--- a/src/JsonWebToken/Cryptography/AesGcmKeyWrapper.netstandard20.cs
+++ b/src/JsonWebToken/Cryptography/AesGcmKeyWrapper.netstandard20.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 using System;
 
 namespace JsonWebToken.Internal

--- a/src/JsonWebToken/Cryptography/AesKeyUnwrapper.cs
+++ b/src/JsonWebToken/Cryptography/AesKeyUnwrapper.cs
@@ -18,7 +18,7 @@ namespace JsonWebToken.Internal
         // The default initialization vector from RFC3394
         private const ulong _defaultIV = 0XA6A6A6A6A6A6A6A6;
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         private readonly AesDecryptor _decryptor;
 #else
         private readonly Aes _aes;
@@ -34,7 +34,7 @@ namespace JsonWebToken.Internal
                 ThrowHelper.ThrowNotSupportedException_AlgorithmForKeyWrap(algorithm);
             }
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (algorithm == KeyManagementAlgorithm.Aes128KW)
             {
                 _decryptor = new AesNiCbc128Decryptor(key.K);
@@ -64,7 +64,7 @@ namespace JsonWebToken.Internal
             {
                 if (disposing)
                 {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                     _decryptor.Dispose();
 #else
                     _decryptorPool.Dispose();
@@ -111,7 +111,7 @@ namespace JsonWebToken.Internal
             int n3 = n >> 3;
             ref byte blockEndRef = ref Unsafe.Add(ref blockRef, 8);
             ref byte tRef7 = ref Unsafe.Add(ref tRef, 7);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             Span<byte> b = stackalloc byte[16];
             ref byte bRef = ref MemoryMarshal.GetReference(b);
 #else
@@ -129,7 +129,7 @@ namespace JsonWebToken.Internal
                         Unsafe.WriteUnaligned(ref blockRef, a);
                         ref byte rCurrent = ref Unsafe.Add(ref rRef, (i - 1) << 3);
                         Unsafe.WriteUnaligned(ref blockEndRef, Unsafe.ReadUnaligned<ulong>(ref rCurrent));
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                         _decryptor.DecryptBlock(ref blockRef, ref bRef);
 #else
                         Span<byte> b = decryptor.TransformFinalBlock(block, 0, 16);
@@ -139,7 +139,7 @@ namespace JsonWebToken.Internal
                         Unsafe.WriteUnaligned(ref rCurrent, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref bRef, 8)));
                     }
                 }
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
             }
             finally
             {
@@ -163,7 +163,7 @@ namespace JsonWebToken.Internal
         public static int GetKeyUnwrappedSize(int wrappedKeySize) 
             => wrappedKeySize - BlockSizeInBytes;
 
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
         private static Aes GetSymmetricAlgorithm(SymmetricJwk key, KeyManagementAlgorithm algorithm)
         {
             if (algorithm.RequiredKeySizeInBits != key.KeySizeInBits)

--- a/src/JsonWebToken/Cryptography/AesKeyWrapper.cs
+++ b/src/JsonWebToken/Cryptography/AesKeyWrapper.cs
@@ -18,7 +18,7 @@ namespace JsonWebToken.Internal
         // The default initialization vector from RFC3394
         private const ulong _defaultIV = 0XA6A6A6A6A6A6A6A6;
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         private readonly AesEncryptor _encryptor;
 #else
         private readonly Aes _aes;
@@ -29,7 +29,7 @@ namespace JsonWebToken.Internal
         public AesKeyWrapper(SymmetricJwk key, EncryptionAlgorithm encryptionAlgorithm, KeyManagementAlgorithm algorithm)
             : base(key, encryptionAlgorithm, algorithm)
         {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (algorithm == KeyManagementAlgorithm.Aes128KW)
             {
                 _encryptor = new AesNiCbc128Encryptor(key.K);
@@ -64,7 +64,7 @@ namespace JsonWebToken.Internal
             {
                 if (disposing)
                 {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                     _encryptor.Dispose();
 #else
                     _encryptorPool.Dispose();
@@ -116,7 +116,7 @@ namespace JsonWebToken.Internal
             ref byte tRef7 = ref Unsafe.Add(ref tRef, 7);
             Unsafe.WriteUnaligned<ulong>(ref tRef, 0L);
             int n3 = n >> 3;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             Span<byte> b = stackalloc byte[16];
             ref byte bRef = ref MemoryMarshal.GetReference(b);
 #else
@@ -130,7 +130,7 @@ namespace JsonWebToken.Internal
                     {
                         Unsafe.WriteUnaligned(ref blockRef, a);
                         Unsafe.WriteUnaligned(ref block2Ref, Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref rRef, i << 3)));
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                     _encryptor.EncryptBlock(ref blockRef, ref bRef);
 #else
                         Span<byte> b = encryptor.TransformFinalBlock(block, 0, 16);
@@ -142,7 +142,7 @@ namespace JsonWebToken.Internal
                         Unsafe.WriteUnaligned(ref Unsafe.Add(ref rRef, i << 3), Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref bRef, 8)));
                     }
                 }
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
             }
             finally
             {
@@ -165,7 +165,7 @@ namespace JsonWebToken.Internal
         public static int GetKeyWrappedSize(EncryptionAlgorithm encryptionAlgorithm) 
             => encryptionAlgorithm.KeyWrappedSizeInBytes;
 
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
         private static Aes GetSymmetricAlgorithm(SymmetricJwk key, KeyManagementAlgorithm algorithm)
         {
             if (algorithm.RequiredKeySizeInBits != key.KeySizeInBits)

--- a/src/JsonWebToken/Cryptography/AesNiCbc128Encryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesNiCbc128Encryptor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -12,19 +12,9 @@ namespace JsonWebToken.Internal
 {
     internal sealed class AesNiCbc128Encryptor : AesEncryptor
     {
-        private const int BlockSize = 16;
+        private readonly Aes128Keys _keys;
 
-        private Vector128<byte> _key0;
-        private Vector128<byte> _key1;
-        private Vector128<byte> _key2;
-        private Vector128<byte> _key3;
-        private Vector128<byte> _key4;
-        private Vector128<byte> _key5;
-        private Vector128<byte> _key6;
-        private Vector128<byte> _key7;
-        private Vector128<byte> _key8;
-        private Vector128<byte> _key9;
-        private Vector128<byte> _key10;
+        private const int BlockSize = 16;
 
         public AesNiCbc128Encryptor(ReadOnlySpan<byte> key)
         {
@@ -34,45 +24,35 @@ namespace JsonWebToken.Internal
             }
 
             ref var keyRef = ref MemoryMarshal.GetReference(key);
-            _key0 = Unsafe.ReadUnaligned<Vector128<byte>>(ref keyRef);
-            _key1 = KeyGenAssist(_key0, 0x01);
-            _key2 = KeyGenAssist(_key1, 0x02);
-            _key3 = KeyGenAssist(_key2, 0x04);
-            _key4 = KeyGenAssist(_key3, 0x08);
-            _key5 = KeyGenAssist(_key4, 0x10);
-            _key6 = KeyGenAssist(_key5, 0x20);
-            _key7 = KeyGenAssist(_key6, 0x40);
-            _key8 = KeyGenAssist(_key7, 0x80);
-            _key9 = KeyGenAssist(_key8, 0x1B);
-            _key10 = KeyGenAssist(_key9, 0x36);
+            _keys.Key0 = Unsafe.ReadUnaligned<Vector128<byte>>(ref keyRef);
+            _keys.Key1 = KeyGenAssist(_keys.Key0, 0x01);
+            _keys.Key2 = KeyGenAssist(_keys.Key1, 0x02);
+            _keys.Key3 = KeyGenAssist(_keys.Key2, 0x04);
+            _keys.Key4 = KeyGenAssist(_keys.Key3, 0x08);
+            _keys.Key5 = KeyGenAssist(_keys.Key4, 0x10);
+            _keys.Key6 = KeyGenAssist(_keys.Key5, 0x20);
+            _keys.Key7 = KeyGenAssist(_keys.Key6, 0x40);
+            _keys.Key8 = KeyGenAssist(_keys.Key7, 0x80);
+            _keys.Key9 = KeyGenAssist(_keys.Key8, 0x1B);
+            _keys.Key10 = KeyGenAssist(_keys.Key9, 0x36);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> KeyGenAssist(Vector128<byte> key, byte control)
         {
             var keyGened = Aes.KeygenAssist(key, control);
-            keyGened = Aes.Shuffle(keyGened.AsInt32(), 0xFF).AsByte();
-            key = Aes.Xor(key, Aes.ShiftLeftLogical128BitLane(key, 4));
-            key = Aes.Xor(key, Aes.ShiftLeftLogical128BitLane(key, 4));
-            key = Aes.Xor(key, Aes.ShiftLeftLogical128BitLane(key, 4));
-            return Aes.Xor(key, keyGened);
+            keyGened = Sse2.Shuffle(keyGened.AsInt32(), 0xFF).AsByte();
+            key = Sse2.Xor(key, Sse2.ShiftLeftLogical128BitLane(key, 4));
+            key = Sse2.Xor(key, Sse2.ShiftLeftLogical128BitLane(key, 4));
+            key = Sse2.Xor(key, Sse2.ShiftLeftLogical128BitLane(key, 4));
+            return Sse2.Xor(key, keyGened);
         }
 
         /// <inheritsdoc />
         public override void Dispose()
         {
             // Clear the keys
-            _key0 = Vector128<byte>.Zero;
-            _key1 = Vector128<byte>.Zero;
-            _key2 = Vector128<byte>.Zero;
-            _key3 = Vector128<byte>.Zero;
-            _key4 = Vector128<byte>.Zero;
-            _key5 = Vector128<byte>.Zero;
-            _key6 = Vector128<byte>.Zero;
-            _key7 = Vector128<byte>.Zero;
-            _key8 = Vector128<byte>.Zero;
-            _key9 = Vector128<byte>.Zero;
-            _key10 = Vector128<byte>.Zero;
+            _keys.Clear();
         }
 
         /// <inheritsdoc />
@@ -88,19 +68,19 @@ namespace JsonWebToken.Internal
             while (Unsafe.IsAddressLessThan(ref inputRef, ref inputEndRef))
             {
                 var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref inputRef);
-                src = Aes.Xor(src, state);
+                src = Sse2.Xor(src, state);
 
-                state = Aes.Xor(src, _key0);
-                state = Aes.Encrypt(state, _key1);
-                state = Aes.Encrypt(state, _key2);
-                state = Aes.Encrypt(state, _key3);
-                state = Aes.Encrypt(state, _key4);
-                state = Aes.Encrypt(state, _key5);
-                state = Aes.Encrypt(state, _key6);
-                state = Aes.Encrypt(state, _key7);
-                state = Aes.Encrypt(state, _key8);
-                state = Aes.Encrypt(state, _key9);
-                state = Aes.EncryptLast(state, _key10);
+                state = Sse2.Xor(src, _keys.Key0);
+                state = Aes.Encrypt(state, _keys.Key1);
+                state = Aes.Encrypt(state, _keys.Key2);
+                state = Aes.Encrypt(state, _keys.Key3);
+                state = Aes.Encrypt(state, _keys.Key4);
+                state = Aes.Encrypt(state, _keys.Key5);
+                state = Aes.Encrypt(state, _keys.Key6);
+                state = Aes.Encrypt(state, _keys.Key7);
+                state = Aes.Encrypt(state, _keys.Key8);
+                state = Aes.Encrypt(state, _keys.Key9);
+                state = Aes.EncryptLast(state, _keys.Key10);
                 Unsafe.WriteUnaligned(ref outputRef, state);
 
                 inputRef = ref Unsafe.AddByteOffset(ref inputRef, (IntPtr)BlockSize);
@@ -115,19 +95,76 @@ namespace JsonWebToken.Internal
             Unsafe.InitBlockUnaligned(ref Unsafe.AddByteOffset(ref outputRef, (IntPtr)left), padding, padding);
             var srcLast = Unsafe.ReadUnaligned<Vector128<byte>>(ref outputRef);
 
-            srcLast = Aes.Xor(srcLast, state);
+            srcLast = Sse2.Xor(srcLast, state);
 
-            state = Aes.Xor(srcLast, _key0);
-            state = Aes.Encrypt(state, _key1);
-            state = Aes.Encrypt(state, _key2);
-            state = Aes.Encrypt(state, _key3);
-            state = Aes.Encrypt(state, _key4);
-            state = Aes.Encrypt(state, _key5);
-            state = Aes.Encrypt(state, _key6);
-            state = Aes.Encrypt(state, _key7);
-            state = Aes.Encrypt(state, _key8);
-            state = Aes.Encrypt(state, _key9);
-            state = Aes.EncryptLast(state, _key10);
+            state = Sse2.Xor(srcLast, _keys.Key0);
+            state = Aes.Encrypt(state, _keys.Key1);
+            state = Aes.Encrypt(state, _keys.Key2);
+            state = Aes.Encrypt(state, _keys.Key3);
+            state = Aes.Encrypt(state, _keys.Key4);
+            state = Aes.Encrypt(state, _keys.Key5);
+            state = Aes.Encrypt(state, _keys.Key6);
+            state = Aes.Encrypt(state, _keys.Key7);
+            state = Aes.Encrypt(state, _keys.Key8);
+            state = Aes.Encrypt(state, _keys.Key9);
+            state = Aes.EncryptLast(state, _keys.Key10);
+            Unsafe.WriteUnaligned(ref outputRef, state);
+        }
+
+
+        /// <inheritsdoc />
+        public void Encrypt3(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
+        {
+            ref var inputRef = ref MemoryMarshal.GetReference(plaintext);
+            ref var outputRef = ref MemoryMarshal.GetReference(ciphertext);
+            ref var nonceRef = ref MemoryMarshal.GetReference(nonce);
+
+            var state = Unsafe.ReadUnaligned<Vector128<byte>>(ref nonceRef);
+            ref var inputEndRef = ref Unsafe.AddByteOffset(ref inputRef, (IntPtr)plaintext.Length - BlockSize + 1);
+
+            while (Unsafe.IsAddressLessThan(ref inputRef, ref inputEndRef))
+            {
+                var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref inputRef);
+                src = Sse2.Xor(src, state);
+
+                state = Sse2.Xor(src, _keys.Key0);
+                state = Aes.Encrypt(state, _keys.Key1);
+                state = Aes.Encrypt(state, _keys.Key2);
+                state = Aes.Encrypt(state, _keys.Key3);
+                state = Aes.Encrypt(state, _keys.Key4);
+                state = Aes.Encrypt(state, _keys.Key5);
+                state = Aes.Encrypt(state, _keys.Key6);
+                state = Aes.Encrypt(state, _keys.Key7);
+                state = Aes.Encrypt(state, _keys.Key8);
+                state = Aes.Encrypt(state, _keys.Key9);
+                state = Aes.EncryptLast(state, _keys.Key10);
+                Unsafe.WriteUnaligned(ref outputRef, state);
+
+                inputRef = ref Unsafe.AddByteOffset(ref inputRef, (IntPtr)BlockSize);
+                outputRef = ref Unsafe.AddByteOffset(ref outputRef, (IntPtr)BlockSize);
+            }
+
+            int left = plaintext.Length & 15;
+
+            // Reuse the destination buffer as last block buffer
+            Unsafe.CopyBlockUnaligned(ref outputRef, ref inputRef, (uint)left);
+            byte padding = (byte)(BlockSize - left);
+            Unsafe.InitBlockUnaligned(ref Unsafe.AddByteOffset(ref outputRef, (IntPtr)left), padding, padding);
+            var srcLast = Unsafe.ReadUnaligned<Vector128<byte>>(ref outputRef);
+
+            srcLast = Sse2.Xor(srcLast, state);
+
+            state = Sse2.Xor(srcLast, _keys.Key0);
+            state = Aes.Encrypt(state, _keys.Key1);
+            state = Aes.Encrypt(state, _keys.Key2);
+            state = Aes.Encrypt(state, _keys.Key3);
+            state = Aes.Encrypt(state, _keys.Key4);
+            state = Aes.Encrypt(state, _keys.Key5);
+            state = Aes.Encrypt(state, _keys.Key6);
+            state = Aes.Encrypt(state, _keys.Key7);
+            state = Aes.Encrypt(state, _keys.Key8);
+            state = Aes.Encrypt(state, _keys.Key9);
+            state = Aes.EncryptLast(state, _keys.Key10);
             Unsafe.WriteUnaligned(ref outputRef, state);
         }
 
@@ -135,17 +172,17 @@ namespace JsonWebToken.Internal
         {
             var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref plaintext);
 
-            block = Aes.Xor(block, _key0);
-            block = Aes.Encrypt(block, _key1);
-            block = Aes.Encrypt(block, _key2);
-            block = Aes.Encrypt(block, _key3);
-            block = Aes.Encrypt(block, _key4);
-            block = Aes.Encrypt(block, _key5);
-            block = Aes.Encrypt(block, _key6);
-            block = Aes.Encrypt(block, _key7);
-            block = Aes.Encrypt(block, _key8);
-            block = Aes.Encrypt(block, _key9);
-            block = Aes.EncryptLast(block, _key10);
+            block = Sse2.Xor(block, _keys.Key0);
+            block = Aes.Encrypt(block, _keys.Key1);
+            block = Aes.Encrypt(block, _keys.Key2);
+            block = Aes.Encrypt(block, _keys.Key3);
+            block = Aes.Encrypt(block, _keys.Key4);
+            block = Aes.Encrypt(block, _keys.Key5);
+            block = Aes.Encrypt(block, _keys.Key6);
+            block = Aes.Encrypt(block, _keys.Key7);
+            block = Aes.Encrypt(block, _keys.Key8);
+            block = Aes.Encrypt(block, _keys.Key9);
+            block = Aes.EncryptLast(block, _keys.Key10);
             Unsafe.WriteUnaligned(ref ciphertext, block);
         }
     }

--- a/src/JsonWebToken/Cryptography/AesNiCbc128Encryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesNiCbc128Encryptor.cs
@@ -111,7 +111,6 @@ namespace JsonWebToken.Internal
             Unsafe.WriteUnaligned(ref outputRef, state);
         }
 
-
         /// <inheritsdoc />
         public void Encrypt3(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
         {

--- a/src/JsonWebToken/Cryptography/AesNiCbc192Encryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesNiCbc192Encryptor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,19 +14,7 @@ namespace JsonWebToken.Internal
     {
         private const int BlockSize = 16;
 
-        private Vector128<byte> _key0;
-        private Vector128<byte> _key1;
-        private Vector128<byte> _key2;
-        private Vector128<byte> _key3;
-        private Vector128<byte> _key4;
-        private Vector128<byte> _key5;
-        private Vector128<byte> _key6;
-        private Vector128<byte> _key7;
-        private Vector128<byte> _key8;
-        private Vector128<byte> _key9;
-        private Vector128<byte> _key10;
-        private Vector128<byte> _key11;
-        private Vector128<byte> _key12;
+        private readonly Aes192Keys _keys;
 
         public AesNiCbc192Encryptor(ReadOnlySpan<byte> key)
         {
@@ -39,72 +27,60 @@ namespace JsonWebToken.Internal
  
             var tmp1 = Unsafe.ReadUnaligned<Vector128<byte>>(ref keyRef);
             var tmp3 = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.Add(ref keyRef, 16));
-            _key0 = tmp1;
-            _key1 = tmp3;
+            _keys.Key0 = tmp1;
+            _keys.Key1 = tmp3;
 
             var tmp4 = KeyGenAssist(ref tmp1, tmp3, 0x01);
-            _key1 = Shuffle(tmp3, tmp1, 0);
-            _key2 = Shuffle(tmp1, tmp4, 1);
+            _keys.Key1 = Shuffle(tmp3, tmp1, 0);
+            _keys.Key2 = Shuffle(tmp1, tmp4, 1);
 
             tmp3 = KeyGenAssist(ref tmp1, tmp4, 0x02);
-            _key3 = tmp1;
+            _keys.Key3 = tmp1;
 
             tmp4 = KeyGenAssist(ref tmp1, tmp3, 0x04);
-            _key4 = Shuffle(tmp3, tmp1, 0);
-            _key5 = Shuffle(tmp1, tmp4, 1);
+            _keys.Key4 = Shuffle(tmp3, tmp1, 0);
+            _keys.Key5 = Shuffle(tmp1, tmp4, 1);
 
             tmp3 = KeyGenAssist(ref tmp1, tmp4, 0x08);
-            _key6 = tmp1;
+            _keys.Key6 = tmp1;
 
             tmp4 = KeyGenAssist(ref tmp1, tmp3, 0x10);
-            _key7 = Shuffle(tmp3, tmp1, 0);
-            _key8 = Shuffle(tmp1, tmp4, 1);
+            _keys.Key7 = Shuffle(tmp3, tmp1, 0);
+            _keys.Key8 = Shuffle(tmp1, tmp4, 1);
        
             tmp3 = KeyGenAssist(ref tmp1, tmp4, 0x20);
-            _key9 = tmp1;
+            _keys.Key9 = tmp1;
 
             tmp4 = KeyGenAssist(ref tmp1, tmp3, 0x40);
-            _key10 = Shuffle(tmp3, tmp1, 0);
-            _key11 = Shuffle(tmp1, tmp4, 1);
+            _keys.Key10 = Shuffle(tmp3, tmp1, 0);
+            _keys.Key11 = Shuffle(tmp1, tmp4, 1);
           
             KeyGenAssist(ref tmp1, tmp4, 0x80);
-            _key12 = tmp1;
+            _keys.Key12 = tmp1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> Shuffle(Vector128<byte> left, Vector128<byte> right, byte control)
-           => Aes.Shuffle(left.AsDouble(), right.AsDouble(), control).AsByte();
+           => Sse2.Shuffle(left.AsDouble(), right.AsDouble(), control).AsByte();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<byte> KeyGenAssist(ref Vector128<byte> tmp1, Vector128<byte> tmp3, byte control)
         {
             var keyGened = Aes.KeygenAssist(tmp3, control);
-            keyGened = Aes.Shuffle(keyGened.AsInt32(), 0x55).AsByte();
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, keyGened);
-            keyGened = Aes.Shuffle(tmp1.AsInt32(), 0xFF).AsByte();
-            return Aes.Xor(Aes.Xor(tmp3, Aes.ShiftLeftLogical128BitLane(tmp3, 4)), keyGened);
+            keyGened = Sse2.Shuffle(keyGened.AsInt32(), 0x55).AsByte();
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, keyGened);
+            keyGened = Sse2.Shuffle(tmp1.AsInt32(), 0xFF).AsByte();
+            return Sse2.Xor(Sse2.Xor(tmp3, Sse2.ShiftLeftLogical128BitLane(tmp3, 4)), keyGened);
         }
 
         /// <inheritsdoc />
         public override void Dispose()
         {
             // Clear the keys
-            _key0 = Vector128<byte>.Zero;
-            _key1 = Vector128<byte>.Zero;
-            _key2 = Vector128<byte>.Zero;
-            _key3 = Vector128<byte>.Zero;
-            _key4 = Vector128<byte>.Zero;
-            _key5 = Vector128<byte>.Zero;
-            _key6 = Vector128<byte>.Zero;
-            _key7 = Vector128<byte>.Zero;
-            _key8 = Vector128<byte>.Zero;
-            _key9 = Vector128<byte>.Zero;
-            _key10 = Vector128<byte>.Zero;
-            _key11 = Vector128<byte>.Zero;
-            _key12 = Vector128<byte>.Zero;
+            _keys.Clear();
         }
 
         /// <inheritsdoc />
@@ -112,29 +88,29 @@ namespace JsonWebToken.Internal
         {
             ref var inputRef = ref MemoryMarshal.GetReference(plaintext);
             ref var outputRef = ref MemoryMarshal.GetReference(ciphertext);
-            ref var ivRef = ref MemoryMarshal.GetReference(nonce);
+            ref var nonceRef = ref MemoryMarshal.GetReference(nonce);
 
-            var state = Unsafe.ReadUnaligned<Vector128<byte>>(ref ivRef);
+            var state = Unsafe.ReadUnaligned<Vector128<byte>>(ref nonceRef);
             ref var inputEndRef = ref Unsafe.AddByteOffset(ref inputRef, (IntPtr)plaintext.Length - BlockSize + 1);
 
             while (Unsafe.IsAddressLessThan(ref inputRef, ref inputEndRef))
             {
                 var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref inputRef);
-                src = Aes.Xor(src, state);
+                src = Sse2.Xor(src, state);
 
-                state = Aes.Xor(src, _key0);
-                state = Aes.Encrypt(state, _key1);
-                state = Aes.Encrypt(state, _key2);
-                state = Aes.Encrypt(state, _key3);
-                state = Aes.Encrypt(state, _key4);
-                state = Aes.Encrypt(state, _key5);
-                state = Aes.Encrypt(state, _key6);
-                state = Aes.Encrypt(state, _key7);
-                state = Aes.Encrypt(state, _key8);
-                state = Aes.Encrypt(state, _key9);
-                state = Aes.Encrypt(state, _key10);
-                state = Aes.Encrypt(state, _key11);
-                state = Aes.EncryptLast(state, _key12);
+                state = Sse2.Xor(src, _keys.Key0);
+                state = Aes.Encrypt(state, _keys.Key1);
+                state = Aes.Encrypt(state, _keys.Key2);
+                state = Aes.Encrypt(state, _keys.Key3);
+                state = Aes.Encrypt(state, _keys.Key4);
+                state = Aes.Encrypt(state, _keys.Key5);
+                state = Aes.Encrypt(state, _keys.Key6);
+                state = Aes.Encrypt(state, _keys.Key7);
+                state = Aes.Encrypt(state, _keys.Key8);
+                state = Aes.Encrypt(state, _keys.Key9);
+                state = Aes.Encrypt(state, _keys.Key10);
+                state = Aes.Encrypt(state, _keys.Key11);
+                state = Aes.EncryptLast(state, _keys.Key12);
                 Unsafe.WriteUnaligned(ref outputRef, state);
 
                 inputRef = ref Unsafe.AddByteOffset(ref inputRef, (IntPtr)BlockSize);
@@ -149,21 +125,21 @@ namespace JsonWebToken.Internal
             Unsafe.InitBlockUnaligned(ref Unsafe.AddByteOffset(ref outputRef, (IntPtr)left), padding, padding);
             var srcLast = Unsafe.ReadUnaligned<Vector128<byte>>(ref outputRef);
 
-            srcLast = Aes.Xor(srcLast, state);
+            srcLast = Sse2.Xor(srcLast, state);
 
-            state = Aes.Xor(srcLast, _key0);
-            state = Aes.Encrypt(state, _key1);
-            state = Aes.Encrypt(state, _key2);
-            state = Aes.Encrypt(state, _key3);
-            state = Aes.Encrypt(state, _key4);
-            state = Aes.Encrypt(state, _key5);
-            state = Aes.Encrypt(state, _key6);
-            state = Aes.Encrypt(state, _key7);
-            state = Aes.Encrypt(state, _key8);
-            state = Aes.Encrypt(state, _key9);
-            state = Aes.Encrypt(state, _key10);
-            state = Aes.Encrypt(state, _key11);
-            state = Aes.EncryptLast(state, _key12);
+            state = Sse2.Xor(srcLast, _keys.Key0);
+            state = Aes.Encrypt(state, _keys.Key1);
+            state = Aes.Encrypt(state, _keys.Key2);
+            state = Aes.Encrypt(state, _keys.Key3);
+            state = Aes.Encrypt(state, _keys.Key4);
+            state = Aes.Encrypt(state, _keys.Key5);
+            state = Aes.Encrypt(state, _keys.Key6);
+            state = Aes.Encrypt(state, _keys.Key7);
+            state = Aes.Encrypt(state, _keys.Key8);
+            state = Aes.Encrypt(state, _keys.Key9);
+            state = Aes.Encrypt(state, _keys.Key10);
+            state = Aes.Encrypt(state, _keys.Key11);
+            state = Aes.EncryptLast(state, _keys.Key12);
             Unsafe.WriteUnaligned(ref outputRef, state);
         }
 
@@ -171,19 +147,19 @@ namespace JsonWebToken.Internal
         {
             var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref plaintext);
 
-            block = Aes.Xor(block, _key0);
-            block = Aes.Encrypt(block, _key1);
-            block = Aes.Encrypt(block, _key2);
-            block = Aes.Encrypt(block, _key3);
-            block = Aes.Encrypt(block, _key4);
-            block = Aes.Encrypt(block, _key5);
-            block = Aes.Encrypt(block, _key6);
-            block = Aes.Encrypt(block, _key7);
-            block = Aes.Encrypt(block, _key8);
-            block = Aes.Encrypt(block, _key9);
-            block = Aes.Encrypt(block, _key10);
-            block = Aes.Encrypt(block, _key11);
-            block = Aes.EncryptLast(block, _key12);
+            block = Sse2.Xor(block, _keys.Key0);
+            block = Aes.Encrypt(block, _keys.Key1);
+            block = Aes.Encrypt(block, _keys.Key2);
+            block = Aes.Encrypt(block, _keys.Key3);
+            block = Aes.Encrypt(block, _keys.Key4);
+            block = Aes.Encrypt(block, _keys.Key5);
+            block = Aes.Encrypt(block, _keys.Key6);
+            block = Aes.Encrypt(block, _keys.Key7);
+            block = Aes.Encrypt(block, _keys.Key8);
+            block = Aes.Encrypt(block, _keys.Key9);
+            block = Aes.Encrypt(block, _keys.Key10);
+            block = Aes.Encrypt(block, _keys.Key11);
+            block = Aes.EncryptLast(block, _keys.Key12);
             Unsafe.WriteUnaligned(ref ciphertext, block);
         }
     }

--- a/src/JsonWebToken/Cryptography/AesNiCbc256Decryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesNiCbc256Decryptor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -14,21 +14,7 @@ namespace JsonWebToken.Internal
     {
         private const int BlockSize = 16;
 
-        private Vector128<byte> _key0;
-        private Vector128<byte> _key1;
-        private Vector128<byte> _key2;
-        private Vector128<byte> _key3;
-        private Vector128<byte> _key4;
-        private Vector128<byte> _key5;
-        private Vector128<byte> _key6;
-        private Vector128<byte> _key7;
-        private Vector128<byte> _key8;
-        private Vector128<byte> _key9;
-        private Vector128<byte> _key10;
-        private Vector128<byte> _key11;
-        private Vector128<byte> _key12;
-        private Vector128<byte> _key13;
-        private Vector128<byte> _key14;
+        private readonly Aes256Keys _keys;
 
         public AesNiCbc256Decryptor(ReadOnlySpan<byte> key)
         {
@@ -41,78 +27,64 @@ namespace JsonWebToken.Internal
 
             var tmp1 = Unsafe.ReadUnaligned<Vector128<byte>>(ref keyRef);
             var tmp3 = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref keyRef, (IntPtr)16));
-            _key14 = tmp1;
-            _key13 = Aes.InverseMixColumns(tmp3);
+            _keys.Key14 = tmp1;
+            _keys.Key13 = Aes.InverseMixColumns(tmp3);
 
             KeyGenAssist1(ref tmp1, tmp3, 0x01);
-            _key12 = Aes.InverseMixColumns(tmp1);
+            _keys.Key12 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key11 = Aes.InverseMixColumns(tmp3);
+            _keys.Key11 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x02);
-            _key10 = Aes.InverseMixColumns(tmp1);
+            _keys.Key10 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key9 = Aes.InverseMixColumns(tmp3);
+            _keys.Key9 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x04);
-            _key8 = Aes.InverseMixColumns(tmp1);
+            _keys.Key8 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key7 = Aes.InverseMixColumns(tmp3);
+            _keys.Key7 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x08);
-            _key6 = Aes.InverseMixColumns(tmp1);
+            _keys.Key6 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key5 = Aes.InverseMixColumns(tmp3);
+            _keys.Key5 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x10);
-            _key4 = Aes.InverseMixColumns(tmp1);
+            _keys.Key4 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key3 = Aes.InverseMixColumns(tmp3);
+            _keys.Key3 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x20);
-            _key2 = Aes.InverseMixColumns(tmp1);
+            _keys.Key2 = Aes.InverseMixColumns(tmp1);
             KeyGenAssist2(tmp1, ref tmp3);
-            _key1 = Aes.InverseMixColumns(tmp3);
+            _keys.Key1 = Aes.InverseMixColumns(tmp3);
             KeyGenAssist1(ref tmp1, tmp3, 0x40);
-            _key0 = (tmp1);
+            _keys.Key0 = (tmp1);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void KeyGenAssist1(ref Vector128<byte> tmp1, Vector128<byte> tmp3, byte control)
         {
             var keyGened = Aes.KeygenAssist(tmp3, control);
-            keyGened = Aes.Shuffle(keyGened.AsInt32(), 0xFF).AsByte();
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, Aes.ShiftLeftLogical128BitLane(tmp1, 4));
-            tmp1 = Aes.Xor(tmp1, keyGened);
+            keyGened = Sse2.Shuffle(keyGened.AsInt32(), 0xFF).AsByte();
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, Sse2.ShiftLeftLogical128BitLane(tmp1, 4));
+            tmp1 = Sse2.Xor(tmp1, keyGened);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void KeyGenAssist2(Vector128<byte> tmp1, ref Vector128<byte> tmp3)
         {
             var keyGened = Aes.KeygenAssist(tmp1, 0);
-            var tmp2 = Aes.Shuffle(keyGened.AsInt32(), 0xAA).AsByte();
-            tmp3 = Aes.Xor(tmp3, Aes.ShiftLeftLogical128BitLane(tmp3, 4));
-            tmp3 = Aes.Xor(tmp3, Aes.ShiftLeftLogical128BitLane(tmp3, 4));
-            tmp3 = Aes.Xor(tmp3, Aes.ShiftLeftLogical128BitLane(tmp3, 4));
-            tmp3 = Aes.Xor(tmp3, tmp2);
+            var tmp2 = Sse2.Shuffle(keyGened.AsInt32(), 0xAA).AsByte();
+            tmp3 = Sse2.Xor(tmp3, Sse2.ShiftLeftLogical128BitLane(tmp3, 4));
+            tmp3 = Sse2.Xor(tmp3, Sse2.ShiftLeftLogical128BitLane(tmp3, 4));
+            tmp3 = Sse2.Xor(tmp3, Sse2.ShiftLeftLogical128BitLane(tmp3, 4));
+            tmp3 = Sse2.Xor(tmp3, tmp2);
         }
 
         /// <inheritsdoc />
         public override void Dispose()
         {
             // Clear the keys
-            _key0 = Vector128<byte>.Zero;
-            _key1 = Vector128<byte>.Zero;
-            _key2 = Vector128<byte>.Zero;
-            _key3 = Vector128<byte>.Zero;
-            _key4 = Vector128<byte>.Zero;
-            _key5 = Vector128<byte>.Zero;
-            _key6 = Vector128<byte>.Zero;
-            _key7 = Vector128<byte>.Zero;
-            _key8 = Vector128<byte>.Zero;
-            _key9 = Vector128<byte>.Zero;
-            _key10 = Vector128<byte>.Zero;
-            _key11 = Vector128<byte>.Zero;
-            _key12 = Vector128<byte>.Zero;
-            _key13 = Vector128<byte>.Zero;
-            _key14 = Vector128<byte>.Zero;
+            _keys.Clear();
         }
 
         public override bool TryDecrypt(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> nonce, Span<byte> plaintext, out int bytesWritten)
@@ -128,22 +100,22 @@ namespace JsonWebToken.Internal
             {
                 var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref inputRef);
                 var lastIn = block;
-                state = Aes.Xor(block, _key0);
+                state = Sse2.Xor(block, _keys.Key0);
 
-                state = Aes.Decrypt(state, _key1);
-                state = Aes.Decrypt(state, _key2);
-                state = Aes.Decrypt(state, _key3);
-                state = Aes.Decrypt(state, _key4);
-                state = Aes.Decrypt(state, _key5);
-                state = Aes.Decrypt(state, _key6);
-                state = Aes.Decrypt(state, _key7);
-                state = Aes.Decrypt(state, _key8);
-                state = Aes.Decrypt(state, _key9);
-                state = Aes.Decrypt(state, _key10);
-                state = Aes.Decrypt(state, _key11);
-                state = Aes.Decrypt(state, _key12);
-                state = Aes.Decrypt(state, _key13);
-                state = Aes.DecryptLast(state, Aes.Xor(_key14, feedback));
+                state = Aes.Decrypt(state, _keys.Key1);
+                state = Aes.Decrypt(state, _keys.Key2);
+                state = Aes.Decrypt(state, _keys.Key3);
+                state = Aes.Decrypt(state, _keys.Key4);
+                state = Aes.Decrypt(state, _keys.Key5);
+                state = Aes.Decrypt(state, _keys.Key6);
+                state = Aes.Decrypt(state, _keys.Key7);
+                state = Aes.Decrypt(state, _keys.Key8);
+                state = Aes.Decrypt(state, _keys.Key9);
+                state = Aes.Decrypt(state, _keys.Key10);
+                state = Aes.Decrypt(state, _keys.Key11);
+                state = Aes.Decrypt(state, _keys.Key12);
+                state = Aes.Decrypt(state, _keys.Key13);
+                state = Aes.DecryptLast(state, Sse2.Xor(_keys.Key14, feedback));
 
                 Unsafe.WriteUnaligned(ref outputRef, state);
 
@@ -156,9 +128,9 @@ namespace JsonWebToken.Internal
             ref byte paddingRef = ref Unsafe.Subtract(ref outputRef, 1);
             byte padding = paddingRef;
             var mask = Vector128.Create(padding);
-            mask = Aes.ShiftLeftLogical128BitLane(mask, (byte)(16 - padding));
+            mask = Sse2.ShiftLeftLogical128BitLane(mask, (byte)(16 - padding));
 
-            if (!Aes.And(mask, state).Equals(mask))
+            if (!Sse2.And(mask, state).Equals(mask))
             {
                 bytesWritten = 0;
                 return false;
@@ -171,21 +143,21 @@ namespace JsonWebToken.Internal
         public override void DecryptBlock(ref byte ciphertext, ref byte plaintext)
         {
             var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref ciphertext);
-            block = Aes.Xor(block, _key0);
-            block = Aes.Decrypt(block, _key1);
-            block = Aes.Decrypt(block, _key2);
-            block = Aes.Decrypt(block, _key3);
-            block = Aes.Decrypt(block, _key4);
-            block = Aes.Decrypt(block, _key5);
-            block = Aes.Decrypt(block, _key6);
-            block = Aes.Decrypt(block, _key7);
-            block = Aes.Decrypt(block, _key8);
-            block = Aes.Decrypt(block, _key9);
-            block = Aes.Decrypt(block, _key10);
-            block = Aes.Decrypt(block, _key11);
-            block = Aes.Decrypt(block, _key12);
-            block = Aes.Decrypt(block, _key13);
-            block = Aes.DecryptLast(block, _key14);
+            block = Sse2.Xor(block, _keys.Key0);
+            block = Aes.Decrypt(block, _keys.Key1);
+            block = Aes.Decrypt(block, _keys.Key2);
+            block = Aes.Decrypt(block, _keys.Key3);
+            block = Aes.Decrypt(block, _keys.Key4);
+            block = Aes.Decrypt(block, _keys.Key5);
+            block = Aes.Decrypt(block, _keys.Key6);
+            block = Aes.Decrypt(block, _keys.Key7);
+            block = Aes.Decrypt(block, _keys.Key8);
+            block = Aes.Decrypt(block, _keys.Key9);
+            block = Aes.Decrypt(block, _keys.Key10);
+            block = Aes.Decrypt(block, _keys.Key11);
+            block = Aes.Decrypt(block, _keys.Key12);
+            block = Aes.Decrypt(block, _keys.Key13);
+            block = Aes.DecryptLast(block, _keys.Key14);
             Unsafe.WriteUnaligned(ref plaintext, block);
         }
     }

--- a/src/JsonWebToken/Cryptography/EcdhKeyWrapper.cs
+++ b/src/JsonWebToken/Cryptography/EcdhKeyWrapper.cs
@@ -51,7 +51,7 @@ namespace JsonWebToken.Internal
                     {
                         return AesKeyWrapper.GetKeyWrappedSize(EncryptionAlgorithm);
                     }
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                     else if (wrappedAlgorithm.Category == AlgorithmCategory.AesGcm)
                     {
                         //return AesGcmKeyWrapper.GetKeyWrapSize(Key);
@@ -78,7 +78,7 @@ namespace JsonWebToken.Internal
                 }
                 else
                 {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                     if (EncryptionAlgorithm.Category == EncryptionType.AesGcm)
                     {
                         return _keySizeInBytes + 8;

--- a/src/JsonWebToken/Cryptography/HmacSha2.cs
+++ b/src/JsonWebToken/Cryptography/HmacSha2.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -13,7 +13,7 @@ namespace JsonWebToken
     /// </summary>
     public abstract class HmacSha2
     {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         private static readonly Vector256<byte> _innerKeyInit = Vector256.Create((byte)0x36);
         private static readonly Vector256<byte> _outerKeyInit = Vector256.Create((byte)0x5c);
 #endif  
@@ -85,7 +85,7 @@ namespace JsonWebToken
 
         private void InitializeIOKeys(ReadOnlySpan<byte> key)
         {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported && (key.Length & 31) == 0)
             {
                 ref byte keyRef = ref MemoryMarshal.GetReference(key);

--- a/src/JsonWebToken/Cryptography/HmacSha384.cs
+++ b/src/JsonWebToken/Cryptography/HmacSha384.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;

--- a/src/JsonWebToken/Cryptography/HmacSha512.cs
+++ b/src/JsonWebToken/Cryptography/HmacSha512.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-#if NETCOREAPP3_0
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
-#endif
 
 namespace JsonWebToken
 {

--- a/src/JsonWebToken/Cryptography/RsaSigner.cs
+++ b/src/JsonWebToken/Cryptography/RsaSigner.cs
@@ -25,7 +25,7 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            if (!key.IsSupported(algorithm))
+            if (!key.SupportSignature(algorithm))
             {
                 ThrowHelper.ThrowNotSupportedException_SignatureAlgorithm(algorithm, key);
             }

--- a/src/JsonWebToken/Cryptography/Sha256.cs
+++ b/src/JsonWebToken/Cryptography/Sha256.cs
@@ -4,7 +4,7 @@ using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -67,7 +67,7 @@ namespace JsonWebToken
 
             ref byte srcRef = ref MemoryMarshal.GetReference(source);
             ref byte srcEndRef = ref Unsafe.Add(ref srcRef, source.Length - Sha256BlockSize + 1);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Ssse3.IsSupported)
             {
                 ref byte src128EndRef = ref Unsafe.Add(ref srcRef, source.Length - 4 * Sha256BlockSize + 1);
@@ -119,7 +119,7 @@ namespace JsonWebToken
             Transform(ref stateRef, ref lastBlockRef, ref wRef);
 
             ref byte destinationRef = ref MemoryMarshal.GetReference(destination);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported)
             {
                 Unsafe.WriteUnaligned(ref destinationRef, Avx2.Shuffle(Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.As<uint, byte>(ref MemoryMarshal.GetReference(state))), _shuffleMask256));
@@ -143,7 +143,7 @@ namespace JsonWebToken
             }
         }
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector128<uint> Gather(ref byte message)
         {
@@ -307,7 +307,7 @@ namespace JsonWebToken
 
         private void Transform(ref uint state, ref byte currentBlock, ref uint w)
         {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             ref byte wRef = ref Unsafe.As<uint, byte>(ref w);
             if (Avx2.IsSupported)
             {
@@ -399,7 +399,7 @@ namespace JsonWebToken
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static uint RotateRight(uint a, byte b)
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             => BitOperations.RotateRight(a, b);
 #else
             => (a >> b) | (a << (32 - b));
@@ -441,7 +441,7 @@ namespace JsonWebToken
             0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
         };
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         // 3, 2, 1, 0, 7, 6, 5, 4,
         // 11, 10, 9, 8, 15, 14, 13, 12,
         // 19, 18, 17, 16, 23, 22, 21, 20,

--- a/src/JsonWebToken/Cryptography/Sha384.cs
+++ b/src/JsonWebToken/Cryptography/Sha384.cs
@@ -3,7 +3,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -66,7 +66,7 @@ namespace JsonWebToken
 
             ref byte srcRef = ref MemoryMarshal.GetReference(source);
             ref byte srcEndRef = ref Unsafe.Add(ref srcRef, source.Length - Sha384BlockSize + 1);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported)
             {
                 ref byte srcSimdEndRef = ref Unsafe.Add(ref srcRef, source.Length - 4 * Sha384BlockSize + 1);
@@ -122,7 +122,7 @@ namespace JsonWebToken
 
             // reverse all the bytes when copying the final state to the output hash.
             ref byte destinationRef = ref MemoryMarshal.GetReference(destination);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported)
             {
                 Unsafe.WriteUnaligned(ref destinationRef, Avx2.Shuffle(Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.As<ulong, byte>(ref stateRef)), Sha512.LittleEndianMask256));

--- a/src/JsonWebToken/Cryptography/Sha512.cs
+++ b/src/JsonWebToken/Cryptography/Sha512.cs
@@ -4,7 +4,7 @@ using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -67,7 +67,7 @@ namespace JsonWebToken
 
             ref byte srcRef = ref MemoryMarshal.GetReference(source);
             ref byte srcEndRef = ref Unsafe.Add(ref srcRef, source.Length - Sha512BlockSize + 1);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported)
             {
                 ref byte srcSimdEndRef = ref Unsafe.Add(ref srcRef, source.Length - 4 * Sha512BlockSize + 1);
@@ -123,7 +123,7 @@ namespace JsonWebToken
 
             // reverse all the bytes when copying the final state to the output hash.
             ref byte destinationRef = ref MemoryMarshal.GetReference(destination);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported)
             {
                 Unsafe.WriteUnaligned(ref destinationRef, Avx2.Shuffle(Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.As<ulong, byte>(ref stateRef)), LittleEndianMask256));
@@ -150,7 +150,7 @@ namespace JsonWebToken
             }
         }
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         internal static Vector256<long> GatherMask = Vector256.Create(0L, 16, 32, 48);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -296,7 +296,7 @@ namespace JsonWebToken
 
         internal static void Transform(ref ulong state, ref byte currentBlock, ref ulong w)
         {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             ref byte wRef = ref Unsafe.As<ulong, byte>(ref w);
             if (Avx2.IsSupported)
             {
@@ -394,7 +394,7 @@ namespace JsonWebToken
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong RotateRight(ulong a, byte b)
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             => BitOperations.RotateRight(a, b);
 #else
             => (a >> b) | (a << (64 - b));
@@ -447,7 +447,7 @@ namespace JsonWebToken
                 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817
             };
 
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector256<ulong> K256(int i)
             => Unsafe.Add(ref k256[0], i);

--- a/src/JsonWebToken/DoesNotReturnAttribute.cs
+++ b/src/JsonWebToken/DoesNotReturnAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Applied to a method that will never return under any circumstance.</summary>

--- a/src/JsonWebToken/ECJwk.cs
+++ b/src/JsonWebToken/ECJwk.cs
@@ -270,19 +270,19 @@ namespace JsonWebToken
         }
 
         /// <inheritdoc />
-        public override bool IsSupported(SignatureAlgorithm algorithm)
+        public override bool SupportSignature(SignatureAlgorithm algorithm)
         {
             return algorithm.Category == AlgorithmCategory.EllipticCurve;
         }
 
         /// <inheritdoc />
-        public override bool IsSupported(KeyManagementAlgorithm algorithm)
+        public override bool SupportKeyManagement(KeyManagementAlgorithm algorithm)
         {
             return algorithm.Category == AlgorithmCategory.EllipticCurve;
         }
 
         /// <inheritdoc />
-        public override bool IsSupported(EncryptionAlgorithm algorithm)
+        public override bool SupportEncryption(EncryptionAlgorithm algorithm)
         {
             return false;
         }

--- a/src/JsonWebToken/ECJwk.net461.cs
+++ b/src/JsonWebToken/ECJwk.net461.cs
@@ -29,13 +29,13 @@ namespace JsonWebToken
         public override bool Equals(Jwk? other) => throw new NotImplementedException();
 
         /// <inheritsdoc />
-        public override bool IsSupported(SignatureAlgorithm algorithm) => throw new NotImplementedException();
+        public override bool SupportSignature(SignatureAlgorithm algorithm) => throw new NotImplementedException();
 
         /// <inheritsdoc />
-        public override bool IsSupported(KeyManagementAlgorithm algorithm) => throw new NotImplementedException();
+        public override bool SupportKeyManagement(KeyManagementAlgorithm algorithm) => throw new NotImplementedException();
 
         /// <inheritsdoc />
-        public override bool IsSupported(EncryptionAlgorithm algorithm) => throw new NotImplementedException();
+        public override bool SupportEncryption(EncryptionAlgorithm algorithm) => throw new NotImplementedException();
 
         /// <inheritsdoc />
         protected override void Canonicalize(IBufferWriter<byte> bufferWriter) => throw new NotImplementedException();

--- a/src/JsonWebToken/Internal/SymmetricSigner.cs
+++ b/src/JsonWebToken/Internal/SymmetricSigner.cs
@@ -5,7 +5,7 @@ using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -112,7 +112,7 @@ namespace JsonWebToken.Internal
             int length = a.Length;
             ref byte first = ref MemoryMarshal.GetReference(a);
             ref byte second = ref MemoryMarshal.GetReference(b);
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             if (Avx2.IsSupported && length == 64)
             {
                 return

--- a/src/JsonWebToken/Jwk.cs
+++ b/src/JsonWebToken/Jwk.cs
@@ -259,7 +259,7 @@ namespace JsonWebToken
         /// </summary>
         /// <param name="algorithm">The <see cref="SignatureAlgorithm"/> to verify.</param>
         /// <returns><c>true</c> if the key support the algorithm; otherwise <c>false</c></returns>
-        public abstract bool IsSupported(SignatureAlgorithm algorithm);
+        public abstract bool SupportSignature(SignatureAlgorithm algorithm);
 
         internal static Jwk FromJsonReader(ref Utf8JsonReader reader)
         {
@@ -442,14 +442,14 @@ namespace JsonWebToken
         /// </summary>
         /// <param name="algorithm">The <see cref="KeyManagementAlgorithm"/> to verify.</param>
         /// <returns><c>true</c> if the key support the algorithm; otherwise <c>false</c></returns>
-        public abstract bool IsSupported(KeyManagementAlgorithm algorithm);
+        public abstract bool SupportKeyManagement(KeyManagementAlgorithm algorithm);
 
         /// <summary>
         /// Determines if the <see cref="Jwk"/> supports the <paramref name="algorithm"/>.
         /// </summary>
         /// <param name="algorithm">The <see cref="EncryptionAlgorithm"/> to verify.</param>
         /// <returns><c>true</c> if the key support the algorithm; otherwise <c>false</c></returns>
-        public abstract bool IsSupported(EncryptionAlgorithm algorithm);
+        public abstract bool SupportEncryption(EncryptionAlgorithm algorithm);
 
         /// <summary>
         /// Returns a string that represents the <see cref="Jwk"/> in JSON.
@@ -517,7 +517,7 @@ namespace JsonWebToken
                     return true;
                 }
 
-                if (IsSupported(algorithm))
+                if (SupportSignature(algorithm))
                 {
                     signer = CreateSigner(algorithm);
                     if (signers.TryAdd(algorithm.Id, signer))
@@ -564,7 +564,7 @@ namespace JsonWebToken
                     }
                 }
 
-                if (IsSupported(algorithm))
+                if (SupportKeyManagement(algorithm))
                 {
                     keyWrapper = CreateKeyWrapper(encryptionAlgorithm, algorithm);
                     if (keyWrappers.TryAdd(algorithmKey, keyWrapper))
@@ -611,7 +611,7 @@ namespace JsonWebToken
                     }
                 }
 
-                if (IsSupported(algorithm))
+                if (SupportKeyManagement(algorithm))
                 {
                     keyUnwrapper = CreateKeyUnwrapper(encryptionAlgorithm, algorithm);
                     if (keyUnwrappers.TryAdd(algorithmKey, keyUnwrapper))
@@ -671,7 +671,7 @@ namespace JsonWebToken
                     }
                 }
 
-                if (IsSupported(encryptionAlgorithm))
+                if (SupportEncryption(encryptionAlgorithm))
                 {
                     encryptor = CreateAuthenticatedEncryptor(encryptionAlgorithm);
                     if (encryptors.TryAdd(algorithmKey, encryptor))
@@ -717,7 +717,7 @@ namespace JsonWebToken
                     }
                 }
 
-                if (IsSupported(encryptionAlgorithm))
+                if (SupportEncryption(encryptionAlgorithm))
                 {
                     decryptor = CreateAuthenticatedDecryptor(encryptionAlgorithm);
                     if (decryptors.TryAdd(algorithmKey, decryptor))
@@ -1169,17 +1169,17 @@ namespace JsonWebToken
                 return ReferenceEquals(this, other);
             }
 
-            public override bool IsSupported(SignatureAlgorithm algorithm)
+            public override bool SupportSignature(SignatureAlgorithm algorithm)
             {
                 return algorithm == SignatureAlgorithm.None;
             }
 
-            public override bool IsSupported(KeyManagementAlgorithm algorithm)
+            public override bool SupportKeyManagement(KeyManagementAlgorithm algorithm)
             {
                 return false;
             }
 
-            public override bool IsSupported(EncryptionAlgorithm algorithm)
+            public override bool SupportEncryption(EncryptionAlgorithm algorithm)
             {
                 return false;
             }

--- a/src/JsonWebToken/KeyWrapper.cs
+++ b/src/JsonWebToken/KeyWrapper.cs
@@ -39,7 +39,7 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            if (!key.IsSupported(algorithm))
+            if (!key.SupportKeyManagement(algorithm))
             {
                 ThrowHelper.ThrowNotSupportedException_AlgorithmForKeyWrap(algorithm);
             }
@@ -133,7 +133,7 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
             }
 
-            if (!key.IsSupported(algorithm))
+            if (!key.SupportKeyManagement(algorithm))
             {
                 ThrowHelper.ThrowNotSupportedException_AlgorithmForKeyWrap(algorithm);
             }

--- a/src/JsonWebToken/NotNullWhenAttribute.cs
+++ b/src/JsonWebToken/NotNullWhenAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2018 Yann Crumeyrolle. All rights reserved.
 // Licensed under the MIT license. See the LICENSE file in the project root for more information.
 
-#if !NETCOREAPP3_0
+#if NETSTANDARD2_0 || NET461 || NETCOREAPP2_1
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>

--- a/src/JsonWebToken/RsaJwk.cs
+++ b/src/JsonWebToken/RsaJwk.cs
@@ -379,19 +379,19 @@ namespace JsonWebToken
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(SignatureAlgorithm algorithm)
+        public override bool SupportSignature(SignatureAlgorithm algorithm)
         {
             return algorithm.Category == AlgorithmCategory.Rsa;
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(KeyManagementAlgorithm algorithm)
+        public override bool SupportKeyManagement(KeyManagementAlgorithm algorithm)
         {
             return algorithm.Category == AlgorithmCategory.Rsa;
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(EncryptionAlgorithm algorithm)
+        public override bool SupportEncryption(EncryptionAlgorithm algorithm)
         {
             return false;
         }

--- a/src/JsonWebToken/SymmetricJwk.cs
+++ b/src/JsonWebToken/SymmetricJwk.cs
@@ -261,19 +261,19 @@ namespace JsonWebToken
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(KeyManagementAlgorithm algorithm)
+        public override bool SupportKeyManagement(KeyManagementAlgorithm algorithm)
         {
             return ((algorithm.Category & AlgorithmCategory.Aes) != 0 && algorithm.RequiredKeySizeInBits == KeySizeInBits) || (algorithm == KeyManagementAlgorithm.Direct);
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(SignatureAlgorithm algorithm)
+        public override bool SupportSignature(SignatureAlgorithm algorithm)
         {
             return algorithm.Category == AlgorithmCategory.Hmac;
         }
 
         /// <inheritsdoc />
-        public override bool IsSupported(EncryptionAlgorithm algorithm)
+        public override bool SupportEncryption(EncryptionAlgorithm algorithm)
         {
             return (algorithm.Category == EncryptionType.AesHmac || algorithm.Category == EncryptionType.AesGcm) && KeySizeInBits >= algorithm.RequiredKeySizeInBits;
         }
@@ -329,7 +329,7 @@ namespace JsonWebToken
         {
             if (encryptionAlgorithm.Category == EncryptionType.AesHmac)
             {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                 if (System.Runtime.Intrinsics.X86.Aes.IsSupported)
                 {
                     if (encryptionAlgorithm == EncryptionAlgorithm.Aes128CbcHmacSha256)
@@ -367,7 +367,7 @@ namespace JsonWebToken
         {
             if (encryptionAlgorithm.Category == EncryptionType.AesHmac)
             {
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
                 if (System.Runtime.Intrinsics.X86.Aes.IsSupported)
                 {
                     if (encryptionAlgorithm == EncryptionAlgorithm.Aes128CbcHmacSha256)
@@ -474,7 +474,7 @@ namespace JsonWebToken
         private static byte[] GenerateKeyBytes(int sizeInBits)
         {
             byte[] key = new byte[sizeInBits >> 3];
-#if NETCOREAPP3_0
+#if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
             RandomNumberGenerator.Fill(key);
             return key;
 #else

--- a/test/JsonWebToken.Tests/Cryptography/AesTests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/AesTests.cs
@@ -19,6 +19,7 @@ namespace JsonWebToken.Tests.Cryptography
 
             // The last 16 bytes are ignored as the test data sets are for ECB mode
             Assert.Equal(expectedCiphertext.ToArray(), ciphertext.Slice(0, ciphertext.Length - 16).ToArray());
+            encryptor.Dispose();
         }
 
         protected void VerifyKeySboxKat(ReadOnlySpan<byte> key, ReadOnlySpan<byte> expectedCiphertext)

--- a/test/JsonWebToken.Tests/ECJwkTests.cs
+++ b/test/JsonWebToken.Tests/ECJwkTests.cs
@@ -43,15 +43,15 @@ namespace JsonWebToken.Tests
         [MemberData(nameof(GetWrappingKeys))]
         public override void IsSupportedKeyWrapping_Success(Jwk key, EncryptionAlgorithm enc, KeyManagementAlgorithm alg)
         {
-            Assert.True(key.IsSupported(alg));
-            Assert.False(key.IsSupported(enc));
+            Assert.True(key.SupportKeyManagement(alg));
+            Assert.False(key.SupportEncryption(enc));
         }
 
         [Theory]
         [MemberData(nameof(GetSignatureCreationKeys))]
         public override void IsSupportedSignature_Success(Jwk key, SignatureAlgorithm alg)
         {
-            Assert.True(key.IsSupported(alg));
+            Assert.True(key.SupportSignature(alg));
         }
 
         public static IEnumerable<object[]> GetWrappingKeys()

--- a/test/JsonWebToken.Tests/JwkTestsBase.cs
+++ b/test/JsonWebToken.Tests/JwkTestsBase.cs
@@ -65,17 +65,17 @@ namespace JsonWebToken.Tests
 
         public virtual void IsSupportedEncryption_Success(Jwk key, EncryptionAlgorithm enc)
         {
-            Assert.True(key.IsSupported(enc));
+            Assert.True(key.SupportEncryption(enc));
         }
 
         public virtual void IsSupportedKeyWrapping_Success(Jwk key, EncryptionAlgorithm enc, KeyManagementAlgorithm alg)
         {
-            Assert.True(key.IsSupported(alg));
+            Assert.True(key.SupportKeyManagement(alg));
         }
 
         public virtual void IsSupportedSignature_Success(Jwk key, SignatureAlgorithm alg)
         {
-            Assert.True(key.IsSupported(alg));
+            Assert.True(key.SupportSignature(alg));
         }
 
         public void Dispose()

--- a/test/JsonWebToken.Tests/RsaJwkTests.cs
+++ b/test/JsonWebToken.Tests/RsaJwkTests.cs
@@ -48,15 +48,15 @@ namespace JsonWebToken.Tests
         [MemberData(nameof(GetWrappingKeys))]
         public override void IsSupportedKeyWrapping_Success(Jwk key, EncryptionAlgorithm enc, KeyManagementAlgorithm alg)
         {
-            Assert.False(key.IsSupported(enc));
-            Assert.True(key.IsSupported(alg));
+            Assert.False(key.SupportEncryption(enc));
+            Assert.True(key.SupportKeyManagement(alg));
         }
 
         [Theory]
         [MemberData(nameof(GetSignatureCreationKeys))]
         public override void IsSupportedSignature_Success(Jwk key, SignatureAlgorithm alg)
         {
-            Assert.True(key.IsSupported(alg));
+            Assert.True(key.SupportSignature(alg));
         }
 
         [Theory]


### PR DESCRIPTION
* Rename IsSupported to SupportedXxx
* Change compiler directive #if NETCOREAPP3_0 to #if !NETSTANDARD2_0 && !NET461 && !NETCOREAPP2_1
* Use a struct for AES keys allowing to clear them in 1 instruction