### PR TITLE
Allow to ignore the nested token reading. 

### DIFF
--- a/src/JsonWebToken/TokenValidationPolicy.cs
+++ b/src/JsonWebToken/TokenValidationPolicy.cs
@@ -42,6 +42,7 @@ namespace JsonWebToken
             Dictionary<string, ICriticalHeaderHandler> criticalHandlers,
             int maximumTokenSizeInBytes,
             bool ignoreCriticalHeader,
+            bool ignoreNestedToken,
             SignatureValidationPolicy? signatureValidation,
             byte[]? issuer,
             byte[][] audiences,
@@ -52,6 +53,7 @@ namespace JsonWebToken
             _criticalHandlers = criticalHandlers ?? throw new ArgumentNullException(nameof(criticalHandlers));
             SignatureValidationPolicy = signatureValidation ?? throw new ArgumentNullException(nameof(signatureValidation));
             _ignoreCriticalHeader = ignoreCriticalHeader;
+            IgnoreNestedToken = ignoreNestedToken;
             MaximumTokenSizeInBytes = maximumTokenSizeInBytes;
             ClockSkew = clockSkew;
             _control = control;
@@ -129,6 +131,8 @@ namespace JsonWebToken
         /// Gets the extension points used to handle the critical headers.
         /// </summary>
         public Dictionary<string, ICriticalHeaderHandler> CriticalHandlers => _criticalHandlers;
+
+        public bool IgnoreNestedToken { get; }
 
         /// <summary>
         /// Try to validate the token, according to the <paramref name="jwt"/>.

--- a/src/JsonWebToken/TokenValidationPolicy.cs
+++ b/src/JsonWebToken/TokenValidationPolicy.cs
@@ -132,6 +132,9 @@ namespace JsonWebToken
         /// </summary>
         public Dictionary<string, ICriticalHeaderHandler> CriticalHandlers => _criticalHandlers;
 
+        /// <summary>
+        /// Ignores the nested token reading and validation. 
+        /// </summary>
         public bool IgnoreNestedToken { get; }
 
         /// <summary>

--- a/src/JsonWebToken/TokenValidationPolicyBuilder.cs
+++ b/src/JsonWebToken/TokenValidationPolicyBuilder.cs
@@ -20,7 +20,8 @@ namespace JsonWebToken
         private int _maximumTokenSizeInBytes = DefaultMaximumTokenSizeInBytes;
         private bool _hasSignatureValidation = false;
         private SignatureValidationPolicy? _signatureValidation = SignatureValidationPolicy.IgnoreSignature;
-        private bool _ignoreCriticalHeader;
+        private bool _ignoreCriticalHeader = false;
+        private bool _ignoreNestedToken;
 
         private byte _control;
         private byte[]? _issuer;
@@ -38,6 +39,7 @@ namespace JsonWebToken
             _signatureValidation = SignatureValidationPolicy.IgnoreSignature;
             _maximumTokenSizeInBytes = DefaultMaximumTokenSizeInBytes;
             _hasSignatureValidation = false;
+            _ignoreNestedToken = false;
             return this;
         }
 
@@ -388,6 +390,16 @@ namespace JsonWebToken
             return this;
         }
 
+        /// <summary>
+        /// Ignores the nested token. If present like a JWE containing a nested JWS, the nested token will be leaved as uncompress and decrypted binary data.
+        /// </summary>
+        /// <returns></returns>
+        public TokenValidationPolicyBuilder IgnoreNestedToken()
+        {
+            _ignoreNestedToken = true;
+            return this;
+        }
+
         private void Validate()
         {
             if (!_hasSignatureValidation)
@@ -405,15 +417,16 @@ namespace JsonWebToken
             Validate();
 
             var policy = new TokenValidationPolicy(
-                _validators.ToArray(),
-                _criticalHeaderHandlers,
-                _maximumTokenSizeInBytes,
-                _ignoreCriticalHeader,
-                _signatureValidation,
-                _issuer,
-                _audiences.ToArray(),
-                _clockSkew,
-                _control);
+                validators: _validators.ToArray(),
+                criticalHandlers: _criticalHeaderHandlers,
+                maximumTokenSizeInBytes: _maximumTokenSizeInBytes,
+                ignoreCriticalHeader: _ignoreCriticalHeader,
+                ignoreNestedToken: !_ignoreNestedToken,
+                signatureValidation: _signatureValidation,
+                issuer: _issuer,
+                audiences: _audiences.ToArray(),
+                clockSkew: _clockSkew,
+                control: _control);
             return policy;
         }
 

--- a/src/JsonWebToken/TokenValidationPolicyBuilder.cs
+++ b/src/JsonWebToken/TokenValidationPolicyBuilder.cs
@@ -421,7 +421,7 @@ namespace JsonWebToken
                 criticalHandlers: _criticalHeaderHandlers,
                 maximumTokenSizeInBytes: _maximumTokenSizeInBytes,
                 ignoreCriticalHeader: _ignoreCriticalHeader,
-                ignoreNestedToken: !_ignoreNestedToken,
+                ignoreNestedToken: _ignoreNestedToken,
                 signatureValidation: _signatureValidation,
                 issuer: _issuer,
                 audiences: _audiences.ToArray(),


### PR DESCRIPTION
Keep the data as uncompressed, uncrypted binary data