### PR TITLE
Avoid to call `MemoryMarshal.GetReference()` without verifying the length

### DIFF
--- a/src/JsonWebToken/CompressionAlgorithm.cs
+++ b/src/JsonWebToken/CompressionAlgorithm.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 using JsonWebToken.Internal;
 

--- a/src/JsonWebToken/Cryptography/Aes128NiCbcEncryptor.cs
+++ b/src/JsonWebToken/Cryptography/Aes128NiCbcEncryptor.cs
@@ -14,8 +14,6 @@ namespace JsonWebToken.Internal
     {
         private readonly Aes128EncryptionKeys _keys;
 
-        private const int BlockSize = 16;
-
         public Aes128NiCbcEncryptor(ReadOnlySpan<byte> key)
         {
             _keys = new Aes128EncryptionKeys(key);
@@ -31,38 +29,50 @@ namespace JsonWebToken.Internal
         /// <inheritsdoc />
         public override void Encrypt(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
         {
-            ref byte input = ref MemoryMarshal.GetReference(plaintext);
-            ref byte output = ref MemoryMarshal.GetReference(ciphertext);
-
-            var state = nonce.AsVector128<byte>();
-            ref byte inputEnd = ref Unsafe.AddByteOffset(ref input, (IntPtr)plaintext.Length - BlockSize + 1);
-
-            while (Unsafe.IsAddressLessThan(ref input, ref inputEnd))
+            if (nonce.Length != 16)
             {
-                var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref input);
-                src = Sse2.Xor(src, state);
-
-                state = Sse2.Xor(src, _keys.Key0);
-                state = Aes.Encrypt(state, _keys.Key1);
-                state = Aes.Encrypt(state, _keys.Key2);
-                state = Aes.Encrypt(state, _keys.Key3);
-                state = Aes.Encrypt(state, _keys.Key4);
-                state = Aes.Encrypt(state, _keys.Key5);
-                state = Aes.Encrypt(state, _keys.Key6);
-                state = Aes.Encrypt(state, _keys.Key7);
-                state = Aes.Encrypt(state, _keys.Key8);
-                state = Aes.Encrypt(state, _keys.Key9);
-                state = Aes.EncryptLast(state, _keys.Key10);
-                Unsafe.WriteUnaligned(ref output, state);
-
-                input = ref Unsafe.AddByteOffset(ref input, (IntPtr)BlockSize);
-                output = ref Unsafe.AddByteOffset(ref output, (IntPtr)BlockSize);
+                ThrowHelper.ThrowArgumentOutOfRangeException_MustBeAtLeast(ExceptionArgument.nonce, 16);
             }
 
-            int left = plaintext.Length & BlockSize - 1;
+            if (ciphertext.Length < GetCiphertextLength(plaintext.Length))
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException_MustBeAtLeast(ExceptionArgument.ciphertext, GetCiphertextLength(plaintext.Length));
+            }
 
-            // Reuse the destination buffer as last block buffer
-            Unsafe.CopyBlockUnaligned(ref output, ref input, (uint)left);
+            var state = nonce.AsVector128<byte>();
+            int left = plaintext.Length & BlockSize - 1;
+            ref byte output = ref MemoryMarshal.GetReference(ciphertext);
+            if (!plaintext.IsEmpty)
+            {
+                ref byte input = ref MemoryMarshal.GetReference(plaintext);
+                ref byte inputEnd = ref Unsafe.AddByteOffset(ref input, (IntPtr)plaintext.Length - BlockSize + 1);
+
+                while (Unsafe.IsAddressLessThan(ref input, ref inputEnd))
+                {
+                    var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref input);
+                    src = Sse2.Xor(src, state);
+
+                    state = Sse2.Xor(src, _keys.Key0);
+                    state = Aes.Encrypt(state, _keys.Key1);
+                    state = Aes.Encrypt(state, _keys.Key2);
+                    state = Aes.Encrypt(state, _keys.Key3);
+                    state = Aes.Encrypt(state, _keys.Key4);
+                    state = Aes.Encrypt(state, _keys.Key5);
+                    state = Aes.Encrypt(state, _keys.Key6);
+                    state = Aes.Encrypt(state, _keys.Key7);
+                    state = Aes.Encrypt(state, _keys.Key8);
+                    state = Aes.Encrypt(state, _keys.Key9);
+                    state = Aes.EncryptLast(state, _keys.Key10);
+                    Unsafe.WriteUnaligned(ref output, state);
+
+                    input = ref Unsafe.AddByteOffset(ref input, (IntPtr)BlockSize);
+                    output = ref Unsafe.AddByteOffset(ref output, (IntPtr)BlockSize);
+                }
+
+                // Reuse the destination buffer as last block buffer
+                Unsafe.CopyBlockUnaligned(ref output, ref input, (uint)left);
+            }
+
             byte padding = (byte)(BlockSize - left);
             Unsafe.InitBlockUnaligned(ref Unsafe.AddByteOffset(ref output, (IntPtr)left), padding, padding);
             var srcLast = Unsafe.ReadUnaligned<Vector128<byte>>(ref output);

--- a/src/JsonWebToken/Cryptography/Aes192NiCbcEncryptor.cs
+++ b/src/JsonWebToken/Cryptography/Aes192NiCbcEncryptor.cs
@@ -12,8 +12,6 @@ namespace JsonWebToken.Internal
 {
     internal sealed class Aes192NiCbcEncryptor : AesEncryptor
     {
-        private const int BlockSize = 16;
-
         private readonly AesEncryption192Keys _keys;
 
         public Aes192NiCbcEncryptor(ReadOnlySpan<byte> key)
@@ -35,40 +33,52 @@ namespace JsonWebToken.Internal
         /// <inheritsdoc />
         public override void Encrypt(ReadOnlySpan<byte> plaintext, ReadOnlySpan<byte> nonce, Span<byte> ciphertext)
         {
-            ref byte input = ref MemoryMarshal.GetReference(plaintext);
-            ref byte output = ref MemoryMarshal.GetReference(ciphertext);
-            
-            var state = nonce.AsVector128<byte>();
-            ref byte inputEnd = ref Unsafe.AddByteOffset(ref input, (IntPtr)plaintext.Length - BlockSize + 1);
-
-            while (Unsafe.IsAddressLessThan(ref input, ref inputEnd))
+            if (nonce.Length != 16)
             {
-                var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref input);
-                src = Sse2.Xor(src, state);
-
-                state = Sse2.Xor(src, _keys.Key0);
-                state = Aes.Encrypt(state, _keys.Key1);
-                state = Aes.Encrypt(state, _keys.Key2);
-                state = Aes.Encrypt(state, _keys.Key3);
-                state = Aes.Encrypt(state, _keys.Key4);
-                state = Aes.Encrypt(state, _keys.Key5);
-                state = Aes.Encrypt(state, _keys.Key6);
-                state = Aes.Encrypt(state, _keys.Key7);
-                state = Aes.Encrypt(state, _keys.Key8);
-                state = Aes.Encrypt(state, _keys.Key9);
-                state = Aes.Encrypt(state, _keys.Key10);
-                state = Aes.Encrypt(state, _keys.Key11);
-                state = Aes.EncryptLast(state, _keys.Key12);
-                Unsafe.WriteUnaligned(ref output, state);
-
-                input = ref Unsafe.AddByteOffset(ref input, (IntPtr)BlockSize);
-                output = ref Unsafe.AddByteOffset(ref output, (IntPtr)BlockSize);
+                ThrowHelper.ThrowArgumentOutOfRangeException_MustBeAtLeast(ExceptionArgument.nonce, 16);
             }
 
-            int left = plaintext.Length & BlockSize - 1;
+            if (ciphertext.Length < GetCiphertextLength(plaintext.Length))
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException_MustBeAtLeast(ExceptionArgument.ciphertext, GetCiphertextLength(plaintext.Length));
+            }
 
-            // Reuse the destination buffer as last block buffer
-            Unsafe.CopyBlockUnaligned(ref output, ref input, (uint)left);
+            var state = nonce.AsVector128<byte>();
+            int left = plaintext.Length & BlockSize - 1;
+            ref byte output = ref MemoryMarshal.GetReference(ciphertext);
+            if (!plaintext.IsEmpty)
+            {
+                ref byte input = ref MemoryMarshal.GetReference(plaintext);
+                ref byte inputEnd = ref Unsafe.AddByteOffset(ref input, (IntPtr)plaintext.Length - BlockSize + 1);
+
+                while (Unsafe.IsAddressLessThan(ref input, ref inputEnd))
+                {
+                    var src = Unsafe.ReadUnaligned<Vector128<byte>>(ref input);
+                    src = Sse2.Xor(src, state);
+
+                    state = Sse2.Xor(src, _keys.Key0);
+                    state = Aes.Encrypt(state, _keys.Key1);
+                    state = Aes.Encrypt(state, _keys.Key2);
+                    state = Aes.Encrypt(state, _keys.Key3);
+                    state = Aes.Encrypt(state, _keys.Key4);
+                    state = Aes.Encrypt(state, _keys.Key5);
+                    state = Aes.Encrypt(state, _keys.Key6);
+                    state = Aes.Encrypt(state, _keys.Key7);
+                    state = Aes.Encrypt(state, _keys.Key8);
+                    state = Aes.Encrypt(state, _keys.Key9);
+                    state = Aes.Encrypt(state, _keys.Key10);
+                    state = Aes.Encrypt(state, _keys.Key11);
+                    state = Aes.EncryptLast(state, _keys.Key12);
+                    Unsafe.WriteUnaligned(ref output, state);
+
+                    input = ref Unsafe.AddByteOffset(ref input, (IntPtr)BlockSize);
+                    output = ref Unsafe.AddByteOffset(ref output, (IntPtr)BlockSize);
+                }
+
+                // Reuse the destination buffer as last block buffer
+                Unsafe.CopyBlockUnaligned(ref output, ref input, (uint)left);
+            }
+
             byte padding = (byte)(BlockSize - left);
             Unsafe.InitBlockUnaligned(ref Unsafe.AddByteOffset(ref output, (IntPtr)left), padding, padding);
             var srcLast = Unsafe.ReadUnaligned<Vector128<byte>>(ref output);

--- a/src/JsonWebToken/Cryptography/Aes256NiCbcDecryptor.cs
+++ b/src/JsonWebToken/Cryptography/Aes256NiCbcDecryptor.cs
@@ -12,8 +12,6 @@ namespace JsonWebToken.Internal
 {
     internal sealed class Aes256NiCbcDecryptor : AesDecryptor
     {
-        private const int BlockSize = 16;
-
         private readonly Aes256DecryptionKeys _keys;
 
         public Aes256NiCbcDecryptor(ReadOnlySpan<byte> key)
@@ -30,41 +28,51 @@ namespace JsonWebToken.Internal
 
         public override unsafe bool TryDecrypt(ReadOnlySpan<byte> ciphertext, ReadOnlySpan<byte> nonce, Span<byte> plaintext, out int bytesWritten)
         {
-            ref byte input = ref MemoryMarshal.GetReference(ciphertext);
-            ref byte output = ref MemoryMarshal.GetReference(plaintext);
-            Vector128<byte> state = default;
-            var feedback = nonce.AsVector128<byte>();
-
-            IntPtr offset = (IntPtr)0;
-            while ((byte*)offset < (byte*)ciphertext.Length)
+            if (nonce.Length != 16)
             {
-                var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref Unsafe.AddByteOffset(ref input, offset));
-                var lastIn = block;
-                state = Sse2.Xor(block, _keys.Key0);
-
-                state = Aes.Decrypt(state, _keys.Key1);
-                state = Aes.Decrypt(state, _keys.Key2);
-                state = Aes.Decrypt(state, _keys.Key3);
-                state = Aes.Decrypt(state, _keys.Key4);
-                state = Aes.Decrypt(state, _keys.Key5);
-                state = Aes.Decrypt(state, _keys.Key6);
-                state = Aes.Decrypt(state, _keys.Key7);
-                state = Aes.Decrypt(state, _keys.Key8);
-                state = Aes.Decrypt(state, _keys.Key9);
-                state = Aes.Decrypt(state, _keys.Key10);
-                state = Aes.Decrypt(state, _keys.Key11);
-                state = Aes.Decrypt(state, _keys.Key12);
-                state = Aes.Decrypt(state, _keys.Key13);
-                state = Aes.DecryptLast(state, Sse2.Xor(_keys.Key14, feedback));
-
-                Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref output, offset), state);
-
-                feedback = lastIn;
-
-                offset += BlockSize;
+                ThrowHelper.ThrowArgumentOutOfRangeException_MustBeAtLeast(ExceptionArgument.nonce, 16);
             }
 
-            byte padding = Unsafe.AddByteOffset(ref output, offset - 1);
+            ref byte output = ref MemoryMarshal.GetReference(plaintext);
+            Vector128<byte> state = default;
+
+            if (!ciphertext.IsEmpty)
+            {
+                ref byte input = ref MemoryMarshal.GetReference(ciphertext);
+                var feedback = nonce.AsVector128<byte>();
+                ref byte inputEnd = ref Unsafe.AddByteOffset(ref input, (IntPtr)ciphertext.Length - BlockSize + 1);
+
+                while (Unsafe.IsAddressLessThan(ref input, ref inputEnd))
+                {
+                    var block = Unsafe.ReadUnaligned<Vector128<byte>>(ref input);
+                    var lastIn = block;
+                    state = Sse2.Xor(block, _keys.Key0);
+
+                    state = Aes.Decrypt(state, _keys.Key1);
+                    state = Aes.Decrypt(state, _keys.Key2);
+                    state = Aes.Decrypt(state, _keys.Key3);
+                    state = Aes.Decrypt(state, _keys.Key4);
+                    state = Aes.Decrypt(state, _keys.Key5);
+                    state = Aes.Decrypt(state, _keys.Key6);
+                    state = Aes.Decrypt(state, _keys.Key7);
+                    state = Aes.Decrypt(state, _keys.Key8);
+                    state = Aes.Decrypt(state, _keys.Key9);
+                    state = Aes.Decrypt(state, _keys.Key10);
+                    state = Aes.Decrypt(state, _keys.Key11);
+                    state = Aes.Decrypt(state, _keys.Key12);
+                    state = Aes.Decrypt(state, _keys.Key13);
+                    state = Aes.DecryptLast(state, Sse2.Xor(_keys.Key14, feedback));
+
+                    Unsafe.WriteUnaligned(ref output, state);
+
+                    feedback = lastIn;
+
+                    input = ref Unsafe.AddByteOffset(ref input, (IntPtr)BlockSize);
+                    output = ref Unsafe.AddByteOffset(ref output, (IntPtr)BlockSize);
+                }
+            }
+
+            byte padding = Unsafe.SubtractByteOffset(ref output, (IntPtr)1);
             if (padding > BlockSize)
             {
                 goto Invalid;

--- a/src/JsonWebToken/Cryptography/AesCbcEncryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesCbcEncryptor.cs
@@ -41,11 +41,6 @@ namespace JsonWebToken.Internal
             ReadOnlySpan<byte> nonce,
             Span<byte> ciphertext)
         {
-            if (plaintext.IsEmpty)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.plaintext);
-            }
-
             if (_disposed)
             {
                 ThrowHelper.ThrowObjectDisposedException(GetType());

--- a/src/JsonWebToken/Cryptography/AesDecryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesDecryptor.cs
@@ -16,6 +16,11 @@ namespace JsonWebToken
     public abstract class AesDecryptor : IDisposable
     {
         /// <summary>
+        /// The size of the AES block.
+        /// </summary>
+        protected const int BlockSize = 16;
+
+        /// <summary>
         /// Try to decrypt the <paramref name="ciphertext"/>. 
         /// </summary>
         /// <param name="ciphertext">The ciphertext to decrypt.</param>

--- a/src/JsonWebToken/Cryptography/AesEncryptor.cs
+++ b/src/JsonWebToken/Cryptography/AesEncryptor.cs
@@ -11,6 +11,11 @@ namespace JsonWebToken
     public abstract class AesEncryptor : IDisposable
     {
         /// <summary>
+        /// The size of the AES block.
+        /// </summary>
+        protected const int BlockSize = 16;
+
+        /// <summary>
         /// Encrypts the <paramref name="plaintext"/>.
         /// </summary>
         /// <param name="plaintext">The plaintext to encrypt.</param>
@@ -27,5 +32,12 @@ namespace JsonWebToken
 
         /// <inheritdoc />
         public abstract void Dispose();
+
+        /// <summary>
+        /// Returns the required ciphertext length.
+        /// </summary>
+        /// <param name="plaintextLength"></param>
+        protected int GetCiphertextLength(int plaintextLength)
+            => (plaintextLength + BlockSize) & ~(BlockSize - 1);
     }
 }

--- a/src/JsonWebToken/Cryptography/Sha256.cs
+++ b/src/JsonWebToken/Cryptography/Sha256.cs
@@ -85,6 +85,12 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentException_DestinationTooSmall(destination.Length, Sha256HashSize);
             }
 
+            if (source.IsEmpty)
+            {
+                EmptyHash.CopyTo(destination);
+                return;
+            }
+
             // init
             Span<uint> state = stackalloc uint[] {
                 0x6a09e667u,
@@ -533,7 +539,16 @@ namespace JsonWebToken
         private static uint Maj(uint x, uint y, uint z)
             => ((x | y) & z) | (x & y);
 
-        private static readonly uint[] k = {
+        private static ReadOnlySpan<byte> EmptyHash => new byte[32]
+        {
+            227, 176, 196, 66, 152, 252, 28, 20, 
+            154, 251, 244, 200, 153, 111, 185, 36,
+            39, 174, 65, 228, 100, 155, 147, 76, 
+            164, 149, 153, 27, 120, 82, 184, 85
+        };
+
+
+    private static readonly uint[] k = {
             0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
             0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
             0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,

--- a/src/JsonWebToken/Cryptography/Sha384.cs
+++ b/src/JsonWebToken/Cryptography/Sha384.cs
@@ -83,6 +83,12 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentException_DestinationTooSmall(destination.Length, Sha384HashSize);
             }
 
+            if (source.IsEmpty)
+            {
+                EmptyHash.CopyTo(destination);
+                return;
+            }
+
             // init
             Span<ulong> state = stackalloc ulong[] {
                 0xcbbb9d5dc1059ed8ul,
@@ -212,5 +218,15 @@ namespace JsonWebToken
                 Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref destinationRef, (IntPtr)40), BinaryPrimitives.ReverseEndianness(Unsafe.AddByteOffset(ref stateRef, (IntPtr)40)));
             }
         }
+
+        private static ReadOnlySpan<byte> EmptyHash => new byte[48]
+        {
+            56, 176, 96, 167, 81, 172, 150, 56, 
+            76, 217, 50, 126, 177, 177, 227, 106, 
+            33, 253, 183, 17, 20, 190, 7, 67, 
+            76, 12, 199, 191, 99, 246, 225, 218, 
+            39, 78, 222, 191, 231, 111, 101, 251, 
+            213, 26, 210, 241, 72, 152, 185, 91
+        };
     }
 }

--- a/src/JsonWebToken/Cryptography/Sha512.cs
+++ b/src/JsonWebToken/Cryptography/Sha512.cs
@@ -85,6 +85,12 @@ namespace JsonWebToken
                 ThrowHelper.ThrowArgumentException_DestinationTooSmall(destination.Length, Sha512HashSize);
             }
 
+            if (source.IsEmpty)
+            {
+                EmptyHash.CopyTo(destination);
+                return;
+            }
+
             // init
             Span<ulong> state = stackalloc ulong[] {
                 0x6a09e667f3bcc908ul,
@@ -519,6 +525,18 @@ namespace JsonWebToken
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong Maj(ulong x, ulong y, ulong z)
             => ((x | y) & z) | (x & y);
+
+        private static ReadOnlySpan<byte> EmptyHash => new byte[64]
+        {
+            207, 131, 225, 53, 126, 239, 184, 189,
+            241, 84, 40, 80, 214, 109, 128, 7, 
+            214, 32, 228, 5, 11, 87, 21, 220, 
+            131, 244, 169, 33, 211, 108, 233, 206, 
+            71, 208, 209, 60, 93, 133, 242, 176, 
+            255, 131, 24, 210, 135, 126, 236, 47, 
+            99, 185, 49, 189, 71, 65, 122, 129, 
+            165, 56, 50, 122, 249, 39, 218, 62
+        };
 
         private static readonly ulong[] _k = {
                 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,

--- a/src/JsonWebToken/EllipticalCurves.cs
+++ b/src/JsonWebToken/EllipticalCurves.cs
@@ -111,7 +111,7 @@ namespace JsonWebToken
         /// </summary>
         /// <param name="crv"></param>
         /// <returns></returns>
-        public static EllipticalCurve FromSpan(ReadOnlySpan<byte> crv)
+        internal static EllipticalCurve FromSpan(ReadOnlySpan<byte> crv)
         {
             ref byte crvRef = ref MemoryMarshal.GetReference(crv);
             if (crv.Length == 5 && crvRef == (byte)'P')

--- a/src/JsonWebToken/EncryptionAlgorithm.cs
+++ b/src/JsonWebToken/EncryptionAlgorithm.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace JsonWebToken
@@ -165,24 +164,22 @@ namespace JsonWebToken
         {
             if (value.Length == 13)
             {
-                ref byte refValue = ref MemoryMarshal.GetReference(value);
-                ulong endValue = IntegerMarshal.ReadUInt64(ref refValue, 5);
-                switch (IntegerMarshal.ReadUInt64(ref refValue))
+                switch (IntegerMarshal.ReadUInt64(value))
                 {
-                    case A128CBC_ when endValue == BC_HS256:
+                    case A128CBC_ when IntegerMarshal.ReadUInt64(value, 5) == BC_HS256:
                         algorithm = Aes128CbcHmacSha256;
                         return true;
-                    case A192CBC_ when endValue == BC_HS384:
+                    case A192CBC_ when IntegerMarshal.ReadUInt64(value, 5) == BC_HS384:
                         algorithm = Aes192CbcHmacSha384;
                         return true;
-                    case A256CBC_ when endValue == BC_HS512:
+                    case A256CBC_ when IntegerMarshal.ReadUInt64(value, 5) == BC_HS512:
                         algorithm = Aes256CbcHmacSha512;
                         return true;
                 }
             }
             else if (value.Length == 7)
             {
-                switch (IntegerMarshal.ReadUInt56(ref MemoryMarshal.GetReference(value)))
+                switch (IntegerMarshal.ReadUInt56(value))
                 {
                     case A128GCM:
                         algorithm = Aes128Gcm;

--- a/src/JsonWebToken/IntegerMarshal.cs
+++ b/src/JsonWebToken/IntegerMarshal.cs
@@ -18,12 +18,16 @@ namespace JsonWebToken
             => Unsafe.ReadUnaligned<ulong>(ref value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ulong ReadUInt64(ReadOnlySpan<byte> value, int elementOffset)
+            => ReadUInt64(ref MemoryMarshal.GetReference(value), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt64(ref byte value, int elementOffset)
             => Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref value, elementOffset));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt56(ReadOnlySpan<byte> value)
-            => ReadUInt64(ref MemoryMarshal.GetReference(value));
+            => ReadUInt56(ref MemoryMarshal.GetReference(value));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ulong ReadUInt56(ref byte value)
@@ -40,6 +44,10 @@ namespace JsonWebToken
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint ReadUInt32(ref byte value)
             => Unsafe.ReadUnaligned<uint>(ref value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static uint ReadUInt32(ReadOnlySpan<byte> value, int elementOffset)
+            => ReadUInt32(ref MemoryMarshal.GetReference(value), elementOffset);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static uint ReadUInt32(ref byte value, int elementOffset)
@@ -62,7 +70,15 @@ namespace JsonWebToken
             => Unsafe.ReadUnaligned<ushort>(ref value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ushort ReadUInt16(ReadOnlySpan<byte> value, int elementOffset)
+            => ReadUInt16(ref MemoryMarshal.GetReference(value), elementOffset);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ushort ReadUInt16(ref byte value, int elementOffset)
             => Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref value, elementOffset));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static byte ReadUInt8(ReadOnlySpan<byte> value)
+            => MemoryMarshal.GetReference(value);
     }
 }

--- a/src/JsonWebToken/KeyManagementAlgorithm.cs
+++ b/src/JsonWebToken/KeyManagementAlgorithm.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace JsonWebToken
@@ -427,14 +425,13 @@ namespace JsonWebToken
         /// <param name="algorithm"></param>
         public static bool TryParse(ReadOnlySpan<byte> value, [NotNullWhen(true)] out KeyManagementAlgorithm? algorithm)
         {
-            ref byte valueRef = ref MemoryMarshal.GetReference(value);
             switch (value.Length)
             {
-                case 3 when IntegerMarshal.ReadUInt24(ref valueRef) == dir:
+                case 3 when IntegerMarshal.ReadUInt24(value) == dir:
                     algorithm = Direct;
                     return true;
-                case 6 when IntegerMarshal.ReadUInt16(ref valueRef, 4) == KW:
-                    switch (IntegerMarshal.ReadUInt32(ref valueRef))
+                case 6 when IntegerMarshal.ReadUInt16(value, 4) == KW:
+                    switch (IntegerMarshal.ReadUInt32(value))
                     {
                         case A128:
                             algorithm = Aes128KW;
@@ -447,17 +444,17 @@ namespace JsonWebToken
                             return true;
                     }
                     break;
-                case 6 when IntegerMarshal.ReadUInt32(ref valueRef) == RSA1 && IntegerMarshal.ReadUInt16(ref valueRef, 4) == _5:
+                case 6 when IntegerMarshal.ReadUInt32(value) == RSA1 && IntegerMarshal.ReadUInt16(value, 4) == _5:
                     algorithm = RsaPkcs1;
                     return true;
-                case 7 when IntegerMarshal.ReadUInt56(ref valueRef) == ECDH_ES:
+                case 7 when IntegerMarshal.ReadUInt56(value) == ECDH_ES:
                     algorithm = EcdhEs;
                     return true;
-                case 8 when IntegerMarshal.ReadUInt64(ref valueRef) == RSA_OAEP:
+                case 8 when IntegerMarshal.ReadUInt64(value) == RSA_OAEP:
                     algorithm = RsaOaep;
                     return true;
-                case 9 when valueRef == (byte)'A':
-                    switch (IntegerMarshal.ReadUInt64(ref valueRef, 1))
+                case 9 when IntegerMarshal.ReadUInt8(value) == (byte)'A':
+                    switch (IntegerMarshal.ReadUInt64(value, 1))
                     {
                         case _128GCMKW:
                             algorithm = Aes128GcmKW;
@@ -470,8 +467,8 @@ namespace JsonWebToken
                             return true;
                     }
                     break;
-                case 12 when IntegerMarshal.ReadUInt64(ref valueRef) == RSA_OAEP:
-                    switch (IntegerMarshal.ReadUInt32(ref valueRef, 8))
+                case 12 when IntegerMarshal.ReadUInt64(value) == RSA_OAEP:
+                    switch (IntegerMarshal.ReadUInt32(value, 8))
                     {
                         case _256:
                             algorithm = RsaOaep256;
@@ -484,8 +481,8 @@ namespace JsonWebToken
                             return true;
                     }
                     break;
-                case 14 when IntegerMarshal.ReadUInt64(ref valueRef) == ECDH_ES_:
-                    switch (IntegerMarshal.ReadUInt64(ref valueRef, 6))
+                case 14 when IntegerMarshal.ReadUInt64(value) == ECDH_ES_:
+                    switch (IntegerMarshal.ReadUInt64(value, 6))
                     {
                         case S_A128KW:
                             algorithm = EcdhEsAes128KW;
@@ -500,16 +497,16 @@ namespace JsonWebToken
                     break;
 
                 // Special case for escaped 'ECDH-ES\u002bAxxxKW' 
-                case 19 when IntegerMarshal.ReadUInt64(ref valueRef) == ECDH_ES_UTF8 /* ECDH-ES\ */ :
-                    switch (IntegerMarshal.ReadUInt64(ref valueRef, 8))
+                case 19 when IntegerMarshal.ReadUInt64(value) == ECDH_ES_UTF8 /* ECDH-ES\ */ :
+                    switch (IntegerMarshal.ReadUInt64(value, 8))
                     {
-                        case u002bA12 when IntegerMarshal.ReadUInt32(ref valueRef, 15) == _28KW:
+                        case u002bA12 when IntegerMarshal.ReadUInt32(value, 15) == _28KW:
                             algorithm = EcdhEsAes128KW;
                             return true;
-                        case u002bA19 when IntegerMarshal.ReadUInt32(ref valueRef, 15) == _92KW:
+                        case u002bA19 when IntegerMarshal.ReadUInt32(value, 15) == _92KW:
                             algorithm = EcdhEsAes192KW;
                             return true;
-                        case u002bA25 when IntegerMarshal.ReadUInt32(ref valueRef, 15) == _56KW:
+                        case u002bA25 when IntegerMarshal.ReadUInt32(value, 15) == _56KW:
                             algorithm = EcdhEsAes256KW;
                             return true;
                     }

--- a/src/JsonWebToken/SignatureAlgorithm.cs
+++ b/src/JsonWebToken/SignatureAlgorithm.cs
@@ -22,67 +22,67 @@ namespace JsonWebToken
         /// <summary>
         /// 'none'
         /// </summary>
-        public static readonly SignatureAlgorithm None = new SignatureAlgorithm(id: JsonWebToken.Algorithms.None, "none", AlgorithmCategory.None, requiredKeySizeInBits: 0, new HashAlgorithmName());
+        public static readonly SignatureAlgorithm None = new SignatureAlgorithm(id: Algorithms.None, "none", AlgorithmCategory.None, requiredKeySizeInBits: 0, new HashAlgorithmName());
 
         /// <summary>
         /// 'HS256'
         /// </summary>
-        public static readonly SignatureAlgorithm HmacSha256 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.HmacSha256, "HS256", AlgorithmCategory.Hmac, requiredKeySizeInBits: 128/*?*/, HashAlgorithmName.SHA256);
+        public static readonly SignatureAlgorithm HmacSha256 = new SignatureAlgorithm(id: Algorithms.HmacSha256, "HS256", AlgorithmCategory.Hmac, requiredKeySizeInBits: 128/*?*/, HashAlgorithmName.SHA256);
 
         /// <summary>
         /// 'HS384'
         /// </summary>
-        public static readonly SignatureAlgorithm HmacSha384 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.HmacSha384, "HS384", AlgorithmCategory.Hmac, requiredKeySizeInBits: 192/*?*/, HashAlgorithmName.SHA384);
+        public static readonly SignatureAlgorithm HmacSha384 = new SignatureAlgorithm(id: Algorithms.HmacSha384, "HS384", AlgorithmCategory.Hmac, requiredKeySizeInBits: 192/*?*/, HashAlgorithmName.SHA384);
 
         /// <summary>
         /// 'HS512'
         /// </summary>
-        public static readonly SignatureAlgorithm HmacSha512 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.HmacSha512, "HS512", AlgorithmCategory.Hmac, requiredKeySizeInBits: 256/*?*/, HashAlgorithmName.SHA512);
+        public static readonly SignatureAlgorithm HmacSha512 = new SignatureAlgorithm(id: Algorithms.HmacSha512, "HS512", AlgorithmCategory.Hmac, requiredKeySizeInBits: 256/*?*/, HashAlgorithmName.SHA512);
 
         /// <summary>
         /// 'RS256'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSha256 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSha256, "RS256", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA256);
+        public static readonly SignatureAlgorithm RsaSha256 = new SignatureAlgorithm(id: Algorithms.RsaSha256, "RS256", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA256);
 
         /// <summary>
         /// 'RS384'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSha384 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSha384, "RS384", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA384);
+        public static readonly SignatureAlgorithm RsaSha384 = new SignatureAlgorithm(id: Algorithms.RsaSha384, "RS384", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA384);
 
         /// <summary>
         /// 'RS512'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSha512 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSha512, "RS512", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA512);
+        public static readonly SignatureAlgorithm RsaSha512 = new SignatureAlgorithm(id: Algorithms.RsaSha512, "RS512", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048/*?*/, HashAlgorithmName.SHA512);
 
         /// <summary>
         /// 'ES256'
         /// </summary>
-        public static readonly SignatureAlgorithm EcdsaSha256 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.EcdsaSha256, "ES256", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 256, HashAlgorithmName.SHA256);
+        public static readonly SignatureAlgorithm EcdsaSha256 = new SignatureAlgorithm(id: Algorithms.EcdsaSha256, "ES256", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 256, HashAlgorithmName.SHA256);
 
         /// <summary>
         /// 'ES384'
         /// </summary>
-        public static readonly SignatureAlgorithm EcdsaSha384 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.EcdsaSha384, "ES384", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 384, HashAlgorithmName.SHA384);
+        public static readonly SignatureAlgorithm EcdsaSha384 = new SignatureAlgorithm(id: Algorithms.EcdsaSha384, "ES384", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 384, HashAlgorithmName.SHA384);
 
         /// <summary>
         /// 'ES512'
         /// </summary>
-        public static readonly SignatureAlgorithm EcdsaSha512 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.EcdsaSha512, "ES512", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 521, HashAlgorithmName.SHA512);
+        public static readonly SignatureAlgorithm EcdsaSha512 = new SignatureAlgorithm(id: Algorithms.EcdsaSha512, "ES512", AlgorithmCategory.EllipticCurve, requiredKeySizeInBits: 521, HashAlgorithmName.SHA512);
 
         /// <summary>
         /// 'PS256'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSsaPssSha256 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSsaPssSha256, "PS256", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA256);
+        public static readonly SignatureAlgorithm RsaSsaPssSha256 = new SignatureAlgorithm(id: Algorithms.RsaSsaPssSha256, "PS256", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA256);
 
         /// <summary>
         /// 'PS384'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSsaPssSha384 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSsaPssSha384, "PS384", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA384);
+        public static readonly SignatureAlgorithm RsaSsaPssSha384 = new SignatureAlgorithm(id: Algorithms.RsaSsaPssSha384, "PS384", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA384);
 
         /// <summary>
         /// 'PS512'
         /// </summary>
-        public static readonly SignatureAlgorithm RsaSsaPssSha512 = new SignatureAlgorithm(id: JsonWebToken.Algorithms.RsaSsaPssSha512, "PS512", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA512);
+        public static readonly SignatureAlgorithm RsaSsaPssSha512 = new SignatureAlgorithm(id: Algorithms.RsaSsaPssSha512, "PS512", AlgorithmCategory.Rsa, requiredKeySizeInBits: 2048, HashAlgorithmName.SHA512);
 
         private readonly int _id;
         private readonly byte[] _utf8Name;
@@ -186,7 +186,8 @@ namespace JsonWebToken
         /// Returns the hash code for this <see cref="SignatureAlgorithm"/>.
         /// </summary>
         /// <returns></returns>
-        public override int GetHashCode() => _id.GetHashCode();
+        public override int GetHashCode() 
+            => _id.GetHashCode();
 
         /// <summary>
         /// Determines whether two specified <see cref="SignatureAlgorithm"/> have the same value.
@@ -308,10 +309,8 @@ namespace JsonWebToken
         {
             if (value.Length == 5)
             {
-                ref byte valueRef = ref MemoryMarshal.GetReference(value);
-                var first = valueRef;
-                var refvalue = IntegerMarshal.ReadUInt32(ref valueRef, 1);
-                switch (refvalue)
+                var first = IntegerMarshal.ReadUInt8(value);
+                switch (IntegerMarshal.ReadUInt32(value, 1))
                 {
                     case S256 when first == (byte)'H':
                         algorithm = HmacSha256;
@@ -407,9 +406,7 @@ namespace JsonWebToken
 
         /// <inheritsddoc />
         public override string ToString()
-        {
-            return Name;
-        }
+            => Name;
 
         internal static SignatureAlgorithm Create(string name)
             => new SignatureAlgorithm(127, name, AlgorithmCategory.None, 0, new HashAlgorithmName());

--- a/test/JsonWebToken.Tests/AesCbcHmacEncryptorTests.cs
+++ b/test/JsonWebToken.Tests/AesCbcHmacEncryptorTests.cs
@@ -71,13 +71,13 @@ namespace JsonWebToken.Tests
             encryptorNi.Encrypt(data, nonce, nonce, ciphertext, authenticationTag);
             var decryptor = new AesCbcHmacDecryptor(key, EncryptionAlgorithm.Aes128CbcHmacSha256);
             bool decrypted = decryptor.TryDecrypt(ciphertext, nonce, nonce, authenticationTag, plaintext, out int bytesWritten);
-            Assert.True(decrypted);
+            Assert.True(decrypted, "decrypted");
             Assert.Equal(data, plaintext.Slice(0, bytesWritten).ToArray());
 
             var decryptorNi = new AesCbcHmacDecryptor(key.K.Slice(0, 16), EncryptionAlgorithm.Aes128CbcHmacSha256, new Aes128NiCbcDecryptor(key.K.Slice(16)));
             plaintext.Clear();
             decrypted = decryptorNi.TryDecrypt(ciphertext, nonce, nonce, authenticationTag, plaintext, out bytesWritten);
-            Assert.True(decrypted);
+            Assert.True(decrypted, "decrypted NI");
             Assert.Equal(data, plaintext.Slice(0, bytesWritten).ToArray());
         }
 #endif
@@ -178,6 +178,7 @@ namespace JsonWebToken.Tests
             bool decrypted = decryptor.TryDecrypt(ciphertext, nonce, nonce, authenticationTag, plaintext, out int bytesWritten);
             Assert.True(decrypted);
         }
+
 #if NETCOREAPP3_0
         [Fact]
         public void EncryptFast_Decrypt()

--- a/test/JsonWebToken.Tests/AlgorithmCompatibilityTests.cs
+++ b/test/JsonWebToken.Tests/AlgorithmCompatibilityTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -31,6 +32,14 @@ namespace JsonWebToken.Tests
             Assert.True(parsed);
             Assert.NotNull(algorithm);
             Assert.Same(expected, algorithm);
+        }
+
+        [Fact]
+        public void TryParseEmpty_ThrowException()
+        {
+            var parsed = TryParse(ReadOnlySpan<byte>.Empty, out var algorithm);
+            Assert.False(parsed);
+            Assert.Null(algorithm);
         }
     }
 

--- a/test/JsonWebToken.Tests/Cryptography/Aes128Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/Aes128Tests.cs
@@ -180,6 +180,12 @@ namespace JsonWebToken.Tests.Cryptography
             VerifyVarTxtKat("00000000000000000000000000000000".HexToByteArray(), plaintext.HexToByteArray(), "00000000000000000000000000000000".HexToByteArray(), expectedCiphertext.HexToByteArray());
         }
 
+        [Fact]
+        public void EmptySpan()
+        {
+            VerifyEmptySpan("00000000000000000000000000000000".HexToByteArray(), "00000000000000000000000000000000".HexToByteArray());
+        }
+
         protected override AesDecryptor CreateDecryptor(ReadOnlySpan<byte> key)
             => new AesCbcDecryptor(key, EncryptionAlgorithm.Aes128CbcHmacSha256);
 

--- a/test/JsonWebToken.Tests/Cryptography/Aes192Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/Aes192Tests.cs
@@ -182,6 +182,12 @@ namespace JsonWebToken.Tests.Cryptography
             VerifyVarTxtKat("000000000000000000000000000000000000000000000000".HexToByteArray(), plaintext.HexToByteArray(), "00000000000000000000000000000000".HexToByteArray(), expectedCiphertext.HexToByteArray());
         }
 
+        [Fact]
+        public void EmptySpan()
+        {
+            VerifyEmptySpan("000000000000000000000000000000000000000000000000".HexToByteArray(), "00000000000000000000000000000000".HexToByteArray());
+        }
+
         protected override AesDecryptor CreateDecryptor(ReadOnlySpan<byte> key)
             => new AesCbcDecryptor(key, EncryptionAlgorithm.Aes192CbcHmacSha384);
 

--- a/test/JsonWebToken.Tests/Cryptography/Aes256Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/Aes256Tests.cs
@@ -173,6 +173,12 @@ namespace JsonWebToken.Tests.Cryptography
             VerifyVarTxtKat("0000000000000000000000000000000000000000000000000000000000000000".HexToByteArray(), plaintext.HexToByteArray(), "00000000000000000000000000000000".HexToByteArray(), expectedCiphertext.HexToByteArray());
         }
 
+        [Fact]
+        public void EmptySpan()
+        {
+            VerifyEmptySpan("0000000000000000000000000000000000000000000000000000000000000000".HexToByteArray(), "00000000000000000000000000000000".HexToByteArray());
+        }
+
         protected override AesDecryptor CreateDecryptor(ReadOnlySpan<byte> key)
             => new AesCbcDecryptor(key, EncryptionAlgorithm.Aes256CbcHmacSha512);
 

--- a/test/JsonWebToken.Tests/Cryptography/AesTests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/AesTests.cs
@@ -43,5 +43,13 @@ namespace JsonWebToken.Tests.Cryptography
             // The last 16 bytes are ignored as the test data sets are for ECB mode
             Assert.Equal(expectedCiphertext.ToArray(), ciphertext.Slice(0, ciphertext.Length - 16).ToArray());
         }
+
+        protected void VerifyEmptySpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> iv)
+        {
+            var encryptor = CreateEncryptor(key);
+            ReadOnlySpan<byte> plaintext = new byte[0];// ReadOnlySpan<byte>.Empty;
+            Span<byte> ciphertext = new byte[(plaintext.Length + 16) & ~15];
+            encryptor.Encrypt(plaintext, iv, ciphertext);
+        }
     }
 }

--- a/test/JsonWebToken.Tests/Cryptography/HmacSha256Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/HmacSha256Tests.cs
@@ -59,5 +59,11 @@ namespace JsonWebToken.Tests.Cryptography
         {
             VerifyHmac(7, "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2");
         }
+
+        [Fact]
+        public void HmacSha256_EmptyKey()
+        {
+            VerifyHmac_Empty("5F8C56F9C91C6CAE4BF58F114BDCE53CF0ED424B191BAAC469181A1194A52260");
+        }
     }
 }

--- a/test/JsonWebToken.Tests/Cryptography/HmacSha384Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/HmacSha384Tests.cs
@@ -59,5 +59,11 @@ namespace JsonWebToken.Tests.Cryptography
         {
             VerifyHmac(7, "6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e");
         }
+
+        [Fact]
+        public void HmacSha384_EmptyKey()
+        {
+            VerifyHmac_Empty("9C6F468D44E2AA9EBEEDBB972F9D30839B6FD9E8982E71076A02E9B61A63DB98D6B692FF8F8D52F999A67EF248C1E573");
+        }
     }
 }

--- a/test/JsonWebToken.Tests/Cryptography/HmacSha512Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/HmacSha512Tests.cs
@@ -59,5 +59,11 @@ namespace JsonWebToken.Tests.Cryptography
         {
             VerifyHmac(7, "e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58");
         }
+
+        [Fact]
+        public void HmacSha512_EmptyKey()
+        {
+            VerifyHmac_Empty("FF28C0274D29D0FAE134E35AD1FBE26C27533718D331BA9C5EF5417479217AE2F1C097172C4F9B55F88DA32ABFA27257CAEA46C0AF51BCDD72340124E777BFCA");
+        }
     }
 }

--- a/test/JsonWebToken.Tests/Cryptography/HmacShaTests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/HmacShaTests.cs
@@ -35,6 +35,22 @@ namespace JsonWebToken.Tests.Cryptography
 
         protected abstract int BlockSize { get; }
 
+        protected void VerifyHmac_Empty(string digest)
+        {
+            // using ReadOnlySpan<byte>.Empty may throw NRE if length not validated correctly
+            var hmac = Create(ReadOnlySpan<byte>.Empty);
+            byte[] digestBytes = ByteUtils.HexToByteArray(digest);
+            byte[] computedDigest = new byte[hmac.HashSize];
+            hmac.ComputeHash(ByteUtils.AsciiBytes("Empty key"), computedDigest);
+
+            Assert.Equal(digestBytes, computedDigest);
+
+            hmac = Create(Array.Empty<byte>());
+            hmac.ComputeHash(ByteUtils.AsciiBytes("Empty key"), computedDigest);
+
+            Assert.Equal(digestBytes, computedDigest);
+        }
+
         protected void VerifyHmac(
             int testCaseId,
             string digest,

--- a/test/JsonWebToken.Tests/Cryptography/Sha256Tests.cs
+++ b/test/JsonWebToken.Tests/Cryptography/Sha256Tests.cs
@@ -11,7 +11,7 @@ namespace JsonWebToken.Tests.Cryptography
         public void Sha256_Empty()
         {
             Verify(
-                Array.Empty<byte>(),
+                ReadOnlySpan<byte>.Empty,
                 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
         }
 

--- a/test/JsonWebToken.Tests/Cryptography/ShaAlgorithmTest.cs
+++ b/test/JsonWebToken.Tests/Cryptography/ShaAlgorithmTest.cs
@@ -34,14 +34,21 @@ namespace JsonWebToken.Tests.Cryptography
             Assert.Throws<ArgumentException>("destination", () => Sha.ComputeHash(Span<byte>.Empty, Span<byte>.Empty));
         }
 
-        protected void Verify(byte[] input, string output)
+        protected void Verify(ReadOnlySpan<byte> input, string output)
         {
             byte[] expected = ByteUtils.HexToByteArray(output);
             byte[] actual;
 
             // Too small
             actual = new byte[expected.Length - 1];
-            Assert.Throws<ArgumentException>("destination", () => Sha.ComputeHash(input, actual));
+            try
+            {
+                Sha.ComputeHash(input, actual);
+            }
+            catch (ArgumentException e)
+            {
+                Assert.Equal("destination", e.ParamName);
+            }
 
             // Just right
             actual = new byte[expected.Length];

--- a/test/JsonWebToken.Tests/FixedTimeEqualsTests.cs
+++ b/test/JsonWebToken.Tests/FixedTimeEqualsTests.cs
@@ -106,6 +106,25 @@ namespace JsonWebToken.Tests
             Assert.False(isEqualA, "value, value missing last byte");
             Assert.False(isEqualB, "value missing last byte, value");
         }
+        
+        [Fact]
+        public static void EmptyReturnTrue()
+        {
+            int byteLength = 0;
+            byte[] rented = ArrayPool<byte>.Shared.Rent(byteLength);
+            Span<byte> testSpan = new Span<byte>(rented, 0, byteLength);
+            Fill(rented, 0, byteLength);
+
+            ReadOnlySpan<byte> emptySpan = ReadOnlySpan<byte>.Empty;
+
+            bool isEqualA = CryptographicOperations.FixedTimeEquals(testSpan, emptySpan);
+            bool isEqualB = CryptographicOperations.FixedTimeEquals(emptySpan, testSpan);
+
+            ArrayPool<byte>.Shared.Return(rented);
+
+            Assert.True(isEqualA, "FixedTimeEquals(testSpan, emptySpan)");
+            Assert.True(isEqualB, "FixedTimeEquals(emptySpan, testSpan)");
+        }
 
         private static void Fill(byte[] data, int offset, int count)
         {

--- a/test/JsonWebToken.Tests/KwTests.cs
+++ b/test/JsonWebToken.Tests/KwTests.cs
@@ -22,5 +22,15 @@ namespace JsonWebToken.Tests
             var unwrapped = kuwp.TryUnwrapKey(wrappedKey, unwrappedKey, null, out int keyWrappedBytesWritten);
             Assert.True(unwrapped);
         }
+
+        [Fact]
+        public void EmptyWrappedKey_ThrowsException()
+        {
+            var kuwp = new AesKeyUnwrapper(_key, EncryptionAlgorithm.Aes128CbcHmacSha256, KeyManagementAlgorithm.Aes128KW);
+            var unwrappedKey = new byte[0];
+            Assert.Throws<ArgumentNullException>(() => kuwp.TryUnwrapKey(ReadOnlySpan<byte>.Empty, unwrappedKey, null, out int keyWrappedBytesWritten));
+            Assert.Throws<ArgumentNullException>(() => kuwp.TryUnwrapKey(Array.Empty<byte>(), unwrappedKey, null, out int keyWrappedBytesWritten));
+            Assert.Throws<ArgumentNullException>(() => kuwp.TryUnwrapKey(default, unwrappedKey, null, out int keyWrappedBytesWritten));
+        }
     }
 }


### PR DESCRIPTION
Because `ReadOnlySpan<byte>.Empty` cause a `NullReferenceException`